### PR TITLE
Changed to reflect caffe2 and pytorch merge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "object_detection/caffe2"]
 	path = object_detection/caffe2/caffe2
-	url = https://github.com/caffe2/caffe2.git
+	url = https://github.com/pytorch/pytorch.git
 [submodule "object_detection/detectron"]
 	path = object_detection/caffe2/detectron
 	url = https://github.com/ddkang/Detectron.git

--- a/object_detection/caffe2/Dockerfile
+++ b/object_detection/caffe2/Dockerfile
@@ -37,13 +37,13 @@ RUN pip install networkx enum
 
 # Build and install caffe2
 WORKDIR /packages
-RUN git clone https://github.com/caffe2/caffe2.git
+RUN git clone https://github.com/pytorch/pytorch.git caffe2
 WORKDIR /packages/caffe2
-RUN git checkout 3dd56c9580ad7ce6d20a4dd922aaac171acf582a
+RUN git checkout 
 RUN git submodule update --init --recursive ; exit 0
-WORKDIR /packages/caffe2/third_party/aten
-RUN git pull origin master
-RUN git checkout fd0020fff6e9a42de8efa7d94589a9168bf721a6
+#WORKDIR /packages/caffe2/third_party/aten
+#RUN git pull origin master
+#RUN git checkout fd0020fff6e9a42de8efa7d94589a9168bf721a6
 WORKDIR /packages/caffe2
 RUN mkdir build
 WORKDIR /packages/caffe2/build


### PR DESCRIPTION
aten is included as part of pytorch, so the submodule is no longer needed