### PR TITLE
[rnn_translator] Add iter_size parameter to increase effective batch size and stabilize 1 GPU reference

### DIFF
--- a/rnn_translator/pytorch/run.sh
+++ b/rnn_translator/pytorch/run.sh
@@ -15,4 +15,5 @@ python3 -m multiproc train.py \
   --seed $SEED \
   --target-bleu $TARGET \
   --epochs 8 \
+  --iter-size 8 \
   --batch-size 128

--- a/rnn_translator/pytorch/train.py
+++ b/rnn_translator/pytorch/train.py
@@ -85,6 +85,8 @@ def parse_args():
     training = parser.add_argument_group('training setup')
     training.add_argument('--batch-size', default=128, type=int,
                           help='batch size for training')
+    training.add_argument('--iter-size', default=1, type=int,
+                          help='iter size for training')
     training.add_argument('--epochs', default=8, type=int,
                           help='number of total epochs to run')
     training.add_argument('--optimization-config',
@@ -245,6 +247,7 @@ def main():
     trainer_options = dict(
         criterion=criterion,
         grad_clip=args.grad_clip,
+        iter_size=args.iter_size,
         save_path=save_path,
         save_freq=args.save_freq,
         save_info={'config': args, 'tokenizer': tokenizer},


### PR DESCRIPTION
This PR adds iter_size parameter and sets iter_size=8 for 1 GPU training of the reference.
Iter_size changes effective batch size, with iter_size=8 training loop accumulates gradients over 8 iterations and then does the weight update.
With that change reference becomes more stable. I tested seeds (1,2,3,...,13) and:
- model converges to target accuracy in 4 epochs for 11 seeds
- for 2 seeds it converges to target accuracy in 5 epochs (seeds: 3 and 13)

This change improves stability, by itself it doesn't change the benchmark, because iter_size modifies effective batch size and batch size can be adjusted even in closed division.