### PR TITLE
Pull in tag sets from various PRs

### DIFF
--- a/compliance/mlperf_compliance/_gnmt_tags.py
+++ b/compliance/mlperf_compliance/_gnmt_tags.py
@@ -1,0 +1,51 @@
+# Copyright 2018 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Keys which only appear in GNMT RNN Translation.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+# Loss smoothing factor
+MODEL_HP_LOSS_SMOOTHING = "model_hp_loss_smoothing"
+
+# Number of layers in encoder and in decoder
+MODEL_HP_NUM_LAYERS = "model_hp_num_layers"
+
+# RNN hidden size
+MODEL_HP_HIDDEN_SIZE = "model_hp_hidden_size"
+
+# Dropout
+MODEL_HP_DROPOUT = "model_hp_dropout"
+
+# Beam size for beam search
+EVAL_HP_BEAM_SIZE = "eval_hp_beam_size"
+
+# Maximum sequence length for training
+TRAIN_HP_MAX_SEQ_LEN = "train_hp_max_sequence_length"
+
+# Maximum sequence length for evaluation
+EVAL_HP_MAX_SEQ_LEN = "eval_hp_max_sequence_length"
+
+# Length normalization constant for beam search
+EVAL_HP_LEN_NORM_CONST = "eval_hp_length_normalization_constant"
+
+# Length normalization factor for beam search
+EVAL_HP_LEN_NORM_FACTOR = "eval_hp_length_normalization_factor"
+
+# Coverage penalty factor for beam search
+EVAL_HP_COV_PENALTY_FACTOR = "eval_hp_coverage_penalty_factor"

--- a/compliance/mlperf_compliance/_ssd_tags.py
+++ b/compliance/mlperf_compliance/_ssd_tags.py
@@ -23,6 +23,20 @@ from __future__ import print_function
 # Pretrained classifer model
 BACKBONE = "backbone"
 
+FEATURE_SIZES = "feature_sizes"
+STEPS = "steps"
+SCALES = "scales"
+ASPECT_RATIOS = "aspect_ratios"
+NUM_DEFAULTS_PER_CELL = "num_defaults_per_cell"
+LOC_CONF_OUT_CHANNELS = "loc_conf_out_channels"
+NUM_DEFAULTS = "num_default_boxes"
+
 # Overlap threshold for NMS
 NMS_THRESHOLD = "nms_threshold"
 NMS_MAX_DETECTIONS = "nms_max_detections"
+
+# data pipeline
+NUM_CROPPING_ITERATIONS = "num_cropping_iterations"
+RANDOM_FLIP_PROBABILITY = "random_flip_probability"
+DATA_NORMALIZATION_MEAN = "data_normalization_mean"
+DATA_NORMALIZATION_STD = "data_normalization_std"

--- a/compliance/mlperf_compliance/_transformer_tags.py
+++ b/compliance/mlperf_compliance/_transformer_tags.py
@@ -1,0 +1,35 @@
+# Copyright 2018 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keys which only appear in transformer.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+INPUT_MAX_LENGTH = "input_max_length"
+
+MODEL_HP_INITIALIZER_GAIN = "model_hp_initializer_gain"
+MODEL_HP_VOCAB_SIZE = "model_hp_vocab_size"
+MODEL_HP_NUM_HIDDEN_LAYERS = "model_hp_hidden_layers"
+MODEL_HP_ATTENTION_DENSE = "model_hp_attention_dense"
+MODEL_HP_ATTENTION_NUM_HEADS = "model_hp_attention_num_heads"
+MODEL_HP_ATTENTION_DROPOUT = "model_hp_attention_dropout"
+MODEL_HP_FFN_DENSE = "model_hp_ffn_dense"
+MODEL_HP_FFN_FILTER = "model_hp_ffn_filter"
+MODEL_HP_RELU_DROPOUT = "model_hp_relu_dropout"
+MODEL_HP_LAYER_POSTPROCESS_DROPOUT = "model_hp_layer_postprocess_dropout"
+MODEL_HP_NORM = "model_hp_norm"
+MODEL_HP_SEQ_BEAM_SEARCH = "model_hp_seq_beam_search"

--- a/compliance/mlperf_compliance/mlperf_log.py
+++ b/compliance/mlperf_compliance/mlperf_log.py
@@ -131,6 +131,13 @@ def _mlperf_print(key, value=None, benchmark=None, stack_offset=0,
   return return_value
 
 
+GNMT_TAG_SET = set(GNMT_TAGS)
+def gnmt_print(key, value=None, stack_offset=1, deferred=False):
+  return _mlperf_print(key=key, value=value, benchmark=GNMT,
+                       stack_offset=stack_offset, tag_set=GNMT_TAG_SET,
+                       deferred=deferred, root_dir=ROOT_DIR_GNMT)
+
+
 MINIGO_TAG_SET = set(MINIGO_TAGS)
 def minigo_print(key, value=None, stack_offset=1, deferred=False):
   return _mlperf_print(key=key, value=value, benchmark=MINIGO,

--- a/compliance/mlperf_compliance/mlperf_log.py
+++ b/compliance/mlperf_compliance/mlperf_log.py
@@ -28,10 +28,16 @@ import sys
 import time
 import uuid
 
-from .tags import *
+from mlperf_compliance.tags import *
+
+ROOT_DIR_GNMT = None
 
 # Set by imagenet_main.py
 ROOT_DIR_RESNET = None
+
+# Set by transformer_main.py and process_data.py
+ROOT_DIR_TRANSFORMER = None
+
 
 PATTERN = re.compile('[a-zA-Z0-9]+')
 
@@ -154,6 +160,13 @@ def ssd_print(key, value=None, stack_offset=1, deferred=False,
   return _mlperf_print(key=key, value=value, benchmark=SSD,
                        stack_offset=stack_offset, tag_set=SSD_TAG_SET,
                        deferred=deferred, extra_print=extra_print)
+
+
+TRANSFORMER_TAG_SET = set(TRANSFORMER_TAGS)
+def transformer_print(key, value=None, stack_offset=2, deferred=False):
+  return _mlperf_print(key=key, value=value, benchmark=TRANSFORMER,
+                       stack_offset=stack_offset, tag_set=TRANSFORMER_TAG_SET,
+                       deferred=deferred, root_dir=ROOT_DIR_TRANSFORMER)
 
 
 MASKRCNN_TAG_SET = set(MASKRCNN_TAGS)

--- a/compliance/mlperf_compliance/mlperf_log.py
+++ b/compliance/mlperf_compliance/mlperf_log.py
@@ -170,7 +170,7 @@ def ssd_print(key, value=None, stack_offset=1, deferred=False,
 
 
 TRANSFORMER_TAG_SET = set(TRANSFORMER_TAGS)
-def transformer_print(key, value=None, stack_offset=2, deferred=False):
+def transformer_print(key, value=None, stack_offset=1, deferred=False):
   return _mlperf_print(key=key, value=value, benchmark=TRANSFORMER,
                        stack_offset=stack_offset, tag_set=TRANSFORMER_TAG_SET,
                        deferred=deferred, root_dir=ROOT_DIR_TRANSFORMER)

--- a/compliance/mlperf_compliance/resnet_log_helper.py
+++ b/compliance/mlperf_compliance/resnet_log_helper.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from . import mlperf_log
+from mlperf_compliance import mlperf_log
 
 _STACK_OFFSET = 2
 

--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -19,13 +19,19 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ._ncf_tags import *
-from ._resnet_tags import *
-from ._ssd_tags import *
+from mlperf_compliance._gnmt_tags import *
+from mlperf_compliance._ncf_tags import *
+from mlperf_compliance._resnet_tags import *
+from mlperf_compliance._ssd_tags import *
+from mlperf_compliance._transformer_tags import *
+
 
 # ==============================================================================
 # == Benchmarks ================================================================
 # ==============================================================================
+
+# rnn_translator
+GNMT = "gnmt"
 
 # reinforcement/
 MINIGO = "minigo"
@@ -97,7 +103,12 @@ SGD = "stochastic_gradient_descent"
 # (where vanilla SGD would be the specific case of momentum=0)
 SGD_WITH_MOMENTUM = "stochastic_gradient_descent_with_momentum"
 
+ADAM = "adam"
+LAZY_ADAM = "lazy_adam"
+
 TRUNCATED_NORMAL = "truncated_normal"
+
+RELU = "relu"
 
 
 # \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -272,6 +283,79 @@ STDOUT_TAG_SET = {
 # ==============================================================================
 # == Benchmark tag sets ========================================================
 # ==============================================================================
+ALL_USED_TAGS = set()
+
+GNMT_TAGS = (
+    RUN_START,
+    RUN_STOP,
+    RUN_FINAL,
+    RUN_SET_RANDOM_SEED,
+
+    PREPROC_VOCAB_SIZE,
+    PREPROC_TOKENIZE_TRAINING,
+    PREPROC_TOKENIZE_EVAL,
+    PREPROC_NUM_TRAIN_EXAMPLES,
+    PREPROC_NUM_EVAL_EXAMPLES,
+
+    INPUT_SIZE,
+    INPUT_BATCH_SIZE,
+    INPUT_ORDER,
+
+    OPT_NAME,
+    OPT_LR,
+    OPT_HP_ADAM_BETA1,
+    OPT_HP_ADAM_BETA2,
+    OPT_HP_ADAM_EPSILON,
+
+    TRAIN_LOOP,
+    TRAIN_EPOCH,
+    TRAIN_CHECKPOINT,
+    TRAIN_HP_MAX_SEQ_LEN,
+
+    EVAL_START,
+    EVAL_SIZE,
+    EVAL_TARGET,
+    EVAL_ACCURACY,
+    EVAL_STOP,
+    EVAL_HP_BEAM_SIZE,
+    EVAL_HP_MAX_SEQ_LEN,
+    EVAL_HP_LEN_NORM_CONST,
+    EVAL_HP_LEN_NORM_FACTOR,
+    EVAL_HP_COV_PENALTY_FACTOR,
+
+    MODEL_HP_LOSS_FN,
+    MODEL_HP_LOSS_SMOOTHING,
+    MODEL_HP_NUM_LAYERS,
+    MODEL_HP_HIDDEN_SIZE,
+    MODEL_HP_DROPOUT
+)
+
+MASKRCNN_TAGS = (
+    RUN_START,
+    RUN_STOP,
+    RUN_FINAL,
+
+    INPUT_BATCH_SIZE,
+    INPUT_ORDER,
+
+    BACKBONE,
+    NMS_THRESHOLD,
+    NMS_MAX_DETECTIONS,
+
+    OPT_NAME,
+    OPT_LR,
+    OPT_MOMENTUM,
+    OPT_WEIGHT_DECAY,
+
+    TRAIN_LOOP,
+    TRAIN_EPOCH,
+
+    EVAL_START,
+    EVAL_SIZE,
+    EVAL_TARGET,
+    EVAL_ACCURACY,
+    EVAL_STOP,
+)
 
 MINIGO_TAGS = (
     RUN_START,
@@ -387,17 +471,35 @@ SSD_TAGS = (
     RUN_START,
     RUN_STOP,
     RUN_FINAL,
+
+    INPUT_SIZE,
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
+
     BACKBONE,
+    FEATURE_SIZES,
+    STEPS,
+    SCALES,
+    ASPECT_RATIOS,
+    NUM_DEFAULTS_PER_CELL,
+    LOC_CONF_OUT_CHANNELS,
+    NUM_DEFAULTS,
     NMS_THRESHOLD,
     NMS_MAX_DETECTIONS,
+
+    NUM_CROPPING_ITERATIONS,
+    RANDOM_FLIP_PROBABILITY,
+    DATA_NORMALIZATION_MEAN,
+    DATA_NORMALIZATION_STD,
+
     OPT_NAME,
     OPT_LR,
     OPT_MOMENTUM,
     OPT_WEIGHT_DECAY,
+
     TRAIN_LOOP,
     TRAIN_EPOCH,
+
     EVAL_START,
     EVAL_SIZE,
     EVAL_TARGET,
@@ -405,29 +507,53 @@ SSD_TAGS = (
     EVAL_STOP,
 )
 
-MASKRCNN_TAGS = (
+TRANSFORMER_TAGS = (
     RUN_START,
     RUN_STOP,
     RUN_FINAL,
+    RUN_SET_RANDOM_SEED,
+
+    PREPROC_NUM_TRAIN_EXAMPLES,
+    PREPROC_NUM_EVAL_EXAMPLES,
+    PREPROC_TOKENIZE_TRAINING,
+    PREPROC_TOKENIZE_EVAL,
+    PREPROC_VOCAB_SIZE,
 
     INPUT_BATCH_SIZE,
+    INPUT_MAX_LENGTH,
     INPUT_ORDER,
-
-    BACKBONE,
-    NMS_THRESHOLD,
-    NMS_MAX_DETECTIONS,
 
     OPT_NAME,
     OPT_LR,
-    OPT_MOMENTUM,
-    OPT_WEIGHT_DECAY,
+    OPT_HP_ADAM_BETA1,
+    OPT_HP_ADAM_BETA2,
+    OPT_HP_ADAM_EPSILON,
 
     TRAIN_LOOP,
     TRAIN_EPOCH,
 
     EVAL_START,
-    EVAL_SIZE,
     EVAL_TARGET,
     EVAL_ACCURACY,
     EVAL_STOP,
+
+    MODEL_HP_INITIALIZER_GAIN,
+    MODEL_HP_VOCAB_SIZE,
+    MODEL_HP_NUM_HIDDEN_LAYERS,
+    MODEL_HP_ATTENTION_DENSE,
+    MODEL_HP_ATTENTION_NUM_HEADS,
+    MODEL_HP_ATTENTION_DROPOUT,
+    MODEL_HP_FFN_DENSE,
+    MODEL_HP_FFN_FILTER,
+    MODEL_HP_RELU_DROPOUT,
+    MODEL_HP_LAYER_POSTPROCESS_DROPOUT,
+    MODEL_HP_NORM,
+    MODEL_HP_SEQ_BEAM_SEARCH,
 )
+
+ALL_USED_TAGS.update(GNMT_TAGS)
+ALL_USED_TAGS.update(MASKRCNN_TAGS)
+ALL_USED_TAGS.update(NCF_TAGS)
+ALL_USED_TAGS.update(RESNET_TAGS)
+ALL_USED_TAGS.update(SSD_TAGS)
+ALL_USED_TAGS.update(TRANSFORMER_TAGS)

--- a/compliance/mlperf_compliance/test_tag_set.py
+++ b/compliance/mlperf_compliance/test_tag_set.py
@@ -1,0 +1,69 @@
+# Copyright 2018 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Verification script to check model tag sets.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import defaultdict
+import re
+
+from mlperf_compliance import _gnmt_tags
+from mlperf_compliance import _ncf_tags
+from mlperf_compliance import _resnet_tags
+from mlperf_compliance import _ssd_tags
+from mlperf_compliance import _transformer_tags
+from mlperf_compliance  import tags
+
+
+_MODEL_TAG_MODULES = [_gnmt_tags, _ncf_tags, _resnet_tags, _ssd_tags,
+                      _transformer_tags]
+
+TAG_PATTERN = re.compile("^[A-Za-z0-9_]+$")
+
+
+def extract_tags(module):
+  output = []
+  for i in dir(module):
+    if i.startswith("_") or not isinstance(getattr(module, i), str):
+      continue
+    output.append(i)
+  return output
+
+
+def check_collisions():
+  defining_modules = defaultdict(list)
+  for module in _MODEL_TAG_MODULES:
+    name = module.__name__
+    for tag in extract_tags(module):
+      defining_modules[tag].append(name)
+
+  duplicate_defs = {k: v for k, v in defining_modules.items() if len(v) > 1}
+  for key in duplicate_defs.keys():
+    print("Variable {} defined multiple times".format(key))
+
+
+def check_format():
+  for tag in sorted(tags.ALL_USED_TAGS):
+    if not TAG_PATTERN.match(tag):
+      print("Malformed tag: {}".format(tag))
+
+
+if __name__ == "__main__":
+  check_collisions()
+  check_format()
+

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.3",
+    version="0.0.4",
     author="Taylor Robie",
     author_email="taylorrobie@google.com",
     description="Tools for logging MLPerf compliance tags.",


### PR DESCRIPTION
I noticed that several PRs have merge conflicts due to the recent change in compliance utils structure. To make everyone's lives easier, I have pulled all of the changes into a util specific PR and will build 0.0.4 of the mlperf_compliance pip package once this PR is merged. That way you don't have to deal with resolving the merge confilcts; just add a line to requirements.txt

Notable changes:
GNMT: @szmigacz
https://github.com/mlperf/training/pull/157
* I changed some tag names in _gnmt_tags.py to match the tag format.
* I did not include the path manipulation for setting `ROOT_DIR_GNMT`. Please override that value in a main function.

SSD: @christ1ne 
https://github.com/mlperf/training/pull/159
* Just pulled in the expanded tag set. (Thanks for that!)

Transformer: @xyhuang
* Added logging specific changes from https://github.com/mlperf/training/pull/158

General:
* Changed some relative paths to absolute paths.
* Added a simple test file to check for tag collisions and perform a basic tag name check.

I couldn't add @szmigacz as a reviewer, but let me know if you're fine with the GNMT changes.