### PR TITLE
Fix/resnet bbox

### DIFF
--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -162,6 +162,8 @@ INPUT_ORDER = "input_order"
 # ResNet random cropping
 INPUT_CENTRAL_CROP = "input_central_crop"
 
+INPUT_CROP_USES_BBOXES = "input_crop_uses_bboxes"
+
 INPUT_DISTORTED_CROP_MIN_OBJ_COV = "input_distorted_crop_min_object_covered"
 INPUT_DISTORTED_CROP_RATIO_RANGE = "input_distorted_crop_aspect_ratio_range"
 INPUT_DISTORTED_CROP_AREA_RANGE = "input_distorted_crop_area_range"

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.4",
+    version="0.0.5",
     author="Taylor Robie",
     author_email="taylorrobie@google.com",
     description="Tools for logging MLPerf compliance tags.",

--- a/image_classification/tensorflow/official/resnet/imagenet_main.py
+++ b/image_classification/tensorflow/official/resnet/imagenet_main.py
@@ -114,20 +114,7 @@ def _parse_example_proto(example_serialized):
   features = tf.parse_single_example(example_serialized, feature_map)
   label = tf.cast(features['image/class/label'], dtype=tf.int32)
 
-  xmin = tf.expand_dims(features['image/object/bbox/xmin'].values, 0)
-  ymin = tf.expand_dims(features['image/object/bbox/ymin'].values, 0)
-  xmax = tf.expand_dims(features['image/object/bbox/xmax'].values, 0)
-  ymax = tf.expand_dims(features['image/object/bbox/ymax'].values, 0)
-
-  # Note that we impose an ordering of (y, x) just to make life difficult.
-  bbox = tf.concat([ymin, xmin, ymax, xmax], 0)
-
-  # Force the variable number of bounding boxes into the shape
-  # [1, num_boxes, coords].
-  bbox = tf.expand_dims(bbox, 0)
-  bbox = tf.transpose(bbox, [0, 2, 1])
-
-  return features['image/encoded'], label, bbox
+  return features['image/encoded'], label
 
 
 def parse_record(raw_record, is_training, dtype):
@@ -145,11 +132,10 @@ def parse_record(raw_record, is_training, dtype):
   Returns:
     Tuple with processed image tensor and one-hot-encoded label tensor.
   """
-  image_buffer, label, bbox = _parse_example_proto(raw_record)
+  image_buffer, label = _parse_example_proto(raw_record)
 
   image = imagenet_preprocessing.preprocess_image(
       image_buffer=image_buffer,
-      bbox=bbox,
       output_height=_DEFAULT_IMAGE_SIZE,
       output_width=_DEFAULT_IMAGE_SIZE,
       num_channels=_NUM_CHANNELS,

--- a/image_classification/tensorflow/official/resnet/imagenet_preprocessing.py
+++ b/image_classification/tensorflow/official/resnet/imagenet_preprocessing.py
@@ -89,9 +89,11 @@ def _decode_crop_and_flip(image_buffer, num_channels):
                           value=max_attempts)
   mlperf_log.resnet_print(key=mlperf_log.INPUT_CROP_USES_BBOXES, value=False)
 
+  bbox = tf.constant([0.0, 0.0, 1.0, 1.0],
+                     dtype=tf.float32, shape=[1, 1, 4])   #From the entire image
   sample_distorted_bounding_box = tf.image.sample_distorted_bounding_box(
       tf.image.extract_jpeg_shape(image_buffer),
-      bounding_boxes=None,
+      bounding_boxes=bbox,
       min_object_covered=min_object_covered,
       aspect_ratio_range=aspect_ratio_range,
       area_range=area_range,

--- a/image_classification/tensorflow/official/resnet/imagenet_preprocessing.py
+++ b/image_classification/tensorflow/official/resnet/imagenet_preprocessing.py
@@ -51,7 +51,7 @@ _CHANNEL_MEANS = [_R_MEAN, _G_MEAN, _B_MEAN]
 _RESIZE_MIN = 256
 
 
-def _decode_crop_and_flip(image_buffer, bbox, num_channels):
+def _decode_crop_and_flip(image_buffer, num_channels):
   """Crops the given image to a random part of the image, and randomly flips.
 
   We use the fused decode_and_crop op, which performs better than the two ops
@@ -60,9 +60,6 @@ def _decode_crop_and_flip(image_buffer, bbox, num_channels):
 
   Args:
     image_buffer: scalar string Tensor representing the raw JPEG image buffer.
-    bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
-      where each coordinate is [0, 1) and the coordinates are arranged as
-      [ymin, xmin, ymax, xmax].
     num_channels: Integer depth of the image buffer for decoding.
 
   Returns:
@@ -90,10 +87,11 @@ def _decode_crop_and_flip(image_buffer, bbox, num_channels):
                           value=area_range)
   mlperf_log.resnet_print(key=mlperf_log.INPUT_DISTORTED_CROP_MAX_ATTEMPTS,
                           value=max_attempts)
+  mlperf_log.resnet_print(key=mlperf_log.INPUT_CROP_USES_BBOXES, value=False)
 
   sample_distorted_bounding_box = tf.image.sample_distorted_bounding_box(
       tf.image.extract_jpeg_shape(image_buffer),
-      bounding_boxes=bbox,
+      bounding_boxes=None,
       min_object_covered=min_object_covered,
       aspect_ratio_range=aspect_ratio_range,
       area_range=area_range,
@@ -251,7 +249,7 @@ def _resize_image(image, height, width):
       align_corners=False)
 
 
-def preprocess_image(image_buffer, bbox, output_height, output_width,
+def preprocess_image(image_buffer, output_height, output_width,
                      num_channels, is_training=False):
   """Preprocesses the given image.
 
@@ -261,9 +259,6 @@ def preprocess_image(image_buffer, bbox, output_height, output_width,
 
   Args:
     image_buffer: scalar string Tensor representing the raw JPEG image buffer.
-    bbox: 3-D float Tensor of bounding boxes arranged [1, num_boxes, coords]
-      where each coordinate is [0, 1) and the coordinates are arranged as
-      [ymin, xmin, ymax, xmax].
     output_height: The height of the image after preprocessing.
     output_width: The width of the image after preprocessing.
     num_channels: Integer depth of the image buffer for decoding.
@@ -275,7 +270,7 @@ def preprocess_image(image_buffer, bbox, output_height, output_width,
   """
   if is_training:
     # For training, we want to randomize some of the distortions.
-    image = _decode_crop_and_flip(image_buffer, bbox, num_channels)
+    image = _decode_crop_and_flip(image_buffer, num_channels)
 
     mlperf_log.resnet_print(key=mlperf_log.INPUT_RESIZE,
                             value=[output_height, output_width])

--- a/image_classification/tensorflow/requirements.txt
+++ b/image_classification/tensorflow/requirements.txt
@@ -1,4 +1,4 @@
 psutil>=5.4.3
 py-cpuinfo>=3.3.0
 google-cloud-bigquery>=0.31.0
-mlperf_compliance==0.0.3
+mlperf_compliance==0.0.5


### PR DESCRIPTION
This PR updates the reference to make it unambiguous that the input to `sample_distorted_bounding_box()` does not use the annotations from the imagenet dataset.