### PR TITLE
minor updates to mlperf logging util: mlperf_compliance==0.0.6

### DIFF
--- a/compliance/mlperf_compliance/mlperf_log.py
+++ b/compliance/mlperf_compliance/mlperf_log.py
@@ -31,9 +31,14 @@ import uuid
 from mlperf_compliance.tags import *
 
 ROOT_DIR_GNMT = None
+ROOT_DIR_MASKRCNN = None
+ROOT_DIR_MINIGO = None
+ROOT_DIR_NCF = None
 
 # Set by imagenet_main.py
 ROOT_DIR_RESNET = None
+
+ROOT_DIR_SSD = None
 
 # Set by transformer_main.py and process_data.py
 ROOT_DIR_TRANSFORMER = None
@@ -138,11 +143,20 @@ def gnmt_print(key, value=None, stack_offset=1, deferred=False):
                        deferred=deferred, root_dir=ROOT_DIR_GNMT)
 
 
+MASKRCNN_TAG_SET = set(MASKRCNN_TAGS)
+def maskrcnn_print(key, value=None, stack_offset=1, deferred=False,
+    extra_print=True):
+  return _mlperf_print(key=key, value=value, benchmark=MASKRCNN,
+                       stack_offset=stack_offset, tag_set=MASKRCNN_TAG_SET,
+                       deferred=deferred, extra_print=extra_print,
+                       root_dir=ROOT_DIR_MASKRCNN)
+
+
 MINIGO_TAG_SET = set(MINIGO_TAGS)
 def minigo_print(key, value=None, stack_offset=1, deferred=False):
   return _mlperf_print(key=key, value=value, benchmark=MINIGO,
                        stack_offset=stack_offset, tag_set=MINIGO_TAG_SET,
-                       deferred=deferred)
+                       deferred=deferred, root_dir=ROOT_DIR_MINIGO)
 
 
 NCF_TAG_SET = set(NCF_TAGS)
@@ -151,7 +165,8 @@ def ncf_print(key, value=None, stack_offset=1, deferred=False,
   # Extra print is needed for the reference NCF because of tqdm.
   return _mlperf_print(key=key, value=value, benchmark=NCF,
                        stack_offset=stack_offset, tag_set=NCF_TAG_SET,
-                       deferred=deferred, extra_print=extra_print)
+                       deferred=deferred, extra_print=extra_print,
+                       root_dir=ROOT_DIR_NCF)
 
 
 RESNET_TAG_SET = set(RESNET_TAGS)
@@ -166,7 +181,8 @@ def ssd_print(key, value=None, stack_offset=1, deferred=False,
               extra_print=True):
   return _mlperf_print(key=key, value=value, benchmark=SSD,
                        stack_offset=stack_offset, tag_set=SSD_TAG_SET,
-                       deferred=deferred, extra_print=extra_print)
+                       deferred=deferred, extra_print=extra_print,
+                       root_dir=ROOT_DIR_SSD)
 
 
 TRANSFORMER_TAG_SET = set(TRANSFORMER_TAGS)
@@ -174,14 +190,6 @@ def transformer_print(key, value=None, stack_offset=1, deferred=False):
   return _mlperf_print(key=key, value=value, benchmark=TRANSFORMER,
                        stack_offset=stack_offset, tag_set=TRANSFORMER_TAG_SET,
                        deferred=deferred, root_dir=ROOT_DIR_TRANSFORMER)
-
-
-MASKRCNN_TAG_SET = set(MASKRCNN_TAGS)
-def maskrcnn_print(key, value=None, stack_offset=1, deferred=False,
-              extra_print=True):
-  return _mlperf_print(key=key, value=value, benchmark=MASKRCNN,
-                       stack_offset=stack_offset, tag_set=MASKRCNN_TAG_SET,
-                       deferred=deferred, extra_print=extra_print)
 
 
 if __name__ == '__main__':

--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -162,6 +162,8 @@ INPUT_ORDER = "input_order"
 # ResNet random cropping
 INPUT_CENTRAL_CROP = "input_central_crop"
 
+INPUT_CROP_USES_BBOXES = "input_crop_uses_bboxes"
+
 INPUT_DISTORTED_CROP_MIN_OBJ_COV = "input_distorted_crop_min_object_covered"
 INPUT_DISTORTED_CROP_RATIO_RANGE = "input_distorted_crop_aspect_ratio_range"
 INPUT_DISTORTED_CROP_AREA_RANGE = "input_distorted_crop_area_range"
@@ -425,6 +427,7 @@ RESNET_TAGS = (
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
     INPUT_CENTRAL_CROP,
+    INPUT_CROP_USES_BBOXES,
     INPUT_DISTORTED_CROP_MIN_OBJ_COV,
     INPUT_DISTORTED_CROP_RATIO_RANGE,
     INPUT_DISTORTED_CROP_AREA_RANGE,

--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -154,6 +154,9 @@ INPUT_BATCH_SIZE = "input_batch_size"
 # should simply provide a good starting point to an interested party.
 INPUT_ORDER = "input_order"
 
+# The shard size (in items) when shuffling in the input pipeline.
+INPUT_SHARD = "input_shard"
+
 
 # --------------------------------------
 # -- Data Augmentation and Alteration --
@@ -302,6 +305,7 @@ GNMT_TAGS = (
     INPUT_SIZE,
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
+    INPUT_SHARD,
 
     OPT_NAME,
     OPT_LR,
@@ -339,6 +343,7 @@ MASKRCNN_TAGS = (
 
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
+    INPUT_SHARD,
 
     BACKBONE,
     NMS_THRESHOLD,
@@ -365,6 +370,8 @@ MINIGO_TAGS = (
     RUN_FINAL,
     RUN_SET_RANDOM_SEED,
 
+    INPUT_SHARD,
+
     TRAIN_LOOP,
     TRAIN_EPOCH,
 
@@ -387,6 +394,7 @@ NCF_TAGS = (
     INPUT_SIZE,
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
+    INPUT_SHARD,
     INPUT_HP_NUM_NEG,
     INPUT_HP_SAMPLE_TRAIN_REPLACEMENT,
     INPUT_STEP_TRAIN_NEG_GEN,
@@ -426,6 +434,7 @@ RESNET_TAGS = (
     INPUT_SIZE,
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
+    INPUT_SHARD,
     INPUT_CENTRAL_CROP,
     INPUT_CROP_USES_BBOXES,
     INPUT_DISTORTED_CROP_MIN_OBJ_COV,
@@ -478,6 +487,7 @@ SSD_TAGS = (
     INPUT_SIZE,
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
+    INPUT_SHARD,
 
     BACKBONE,
     FEATURE_SIZES,
@@ -525,6 +535,7 @@ TRANSFORMER_TAGS = (
     INPUT_BATCH_SIZE,
     INPUT_MAX_LENGTH,
     INPUT_ORDER,
+    INPUT_SHARD,
 
     OPT_NAME,
     OPT_LR,

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.5",
+    version="0.0.6",
     author="Taylor Robie",
     author_email="taylorrobie@google.com",
     description="Tools for logging MLPerf compliance tags.",

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.4",
+    version="0.0.5",
     author="Taylor Robie",
     author_email="taylorrobie@google.com",
     description="Tools for logging MLPerf compliance tags.",

--- a/image_classification/tensorflow/requirements.txt
+++ b/image_classification/tensorflow/requirements.txt
@@ -1,4 +1,4 @@
 psutil>=5.4.3
 py-cpuinfo>=3.3.0
 google-cloud-bigquery>=0.31.0
-mlperf_compliance==0.0.5
+mlperf_compliance==0.0.6

--- a/image_classification/tensorflow/requirements.txt
+++ b/image_classification/tensorflow/requirements.txt
@@ -1,4 +1,4 @@
 psutil>=5.4.3
 py-cpuinfo>=3.3.0
 google-cloud-bigquery>=0.31.0
-mlperf_compliance==0.0.3
+mlperf_compliance==0.0.5

--- a/recommendation/pytorch/requirements.txt
+++ b/recommendation/pytorch/requirements.txt
@@ -1,4 +1,4 @@
 tqdm==4.20.0
 scipy
 pandas
-mlperf_compliance==0.0.1
+mlperf_compliance==0.0.5

--- a/recommendation/pytorch/requirements.txt
+++ b/recommendation/pytorch/requirements.txt
@@ -1,4 +1,4 @@
 tqdm==4.20.0
 scipy
 pandas
-mlperf_compliance==0.0.5
+mlperf_compliance==0.0.6

--- a/reinforcement/tensorflow/minigo/requirements.txt
+++ b/reinforcement/tensorflow/minigo/requirements.txt
@@ -14,4 +14,4 @@ httplib2
 google-cloud-storage
 google-auth
 oauth2client==4.1
-mlperf_compliance==0.0.2
+mlperf_compliance==0.0.5

--- a/reinforcement/tensorflow/minigo/requirements.txt
+++ b/reinforcement/tensorflow/minigo/requirements.txt
@@ -14,4 +14,4 @@ httplib2
 google-cloud-storage
 google-auth
 oauth2client==4.1
-mlperf_compliance==0.0.5
+mlperf_compliance==0.0.6


### PR DESCRIPTION
This PR just fixes a couple inconsistencies in the logging util. I just figured this was a good time to do a bit of linting before building 0.0.5 so that the util includes the recent Transformer annotations.