### PR TITLE
Fix transformer input filename pattern matching

### DIFF
--- a/translation/tensorflow/process_data.py
+++ b/translation/tensorflow/process_data.py
@@ -76,6 +76,8 @@ _VOCAB_FILE = "vocab.ende.%d" % _TARGET_VOCAB_SIZE
 
 # Strings to inclue in the generated files.
 _PREFIX = "wmt32k"
+_COMPILE_TAG = "compiled"
+_ENCODE_TAG = "encoded"
 _TRAIN_TAG = "train"
 _EVAL_TAG = "dev"  # Following WMT and Tensor2Tensor conventions, in which the
                    # evaluation datasets are tagged as "dev" for development.
@@ -231,7 +233,7 @@ def compile_files(data_dir, raw_files, tag):
     Full path of compiled input and target files.
   """
   tf.logging.info("Compiling files with tag %s." % tag)
-  filename = "%s-%s" % (_PREFIX, tag)
+  filename = "%s-%s-%s" % (_PREFIX, _COMPILE_TAG, tag)
   input_compiled_file = os.path.join(data_dir, filename + ".lang1")
   target_compiled_file = os.path.join(data_dir, filename + ".lang2")
 
@@ -317,7 +319,8 @@ def encode_and_save_files(
 def shard_filename(path, tag, shard_num, total_shards):
   """Create filename for data shard."""
   return os.path.join(
-      path, "%s-%s-%.5d-of-%.5d" % (_PREFIX, tag, shard_num, total_shards))
+      path, "%s-%s-%s-%.5d-of-%.5d" %
+      (_PREFIX, _ENCODE_TAG, tag, shard_num, total_shards))
 
 
 def shuffle_records(fname):

--- a/translation/tensorflow/transformer/utils/dataset.py
+++ b/translation/tensorflow/transformer/utils/dataset.py
@@ -243,7 +243,7 @@ def _read_and_batch_from_files(
 
 def train_input_fn(params):
   """Load and return dataset of batched examples for use during training."""
-  file_pattern = os.path.join(getattr(params, "data_dir", ""), "*train*")
+  file_pattern = os.path.join(getattr(params, "data_dir", ""), "*encoded-train*")
   return _read_and_batch_from_files(
       file_pattern, params.batch_size, params.max_length, params.num_cpu_cores,
       shuffle=True, repeat=params.repeat_dataset)
@@ -251,7 +251,7 @@ def train_input_fn(params):
 
 def eval_input_fn(params):
   """Load and return dataset of batched examples for use during evaluation."""
-  file_pattern = os.path.join(getattr(params, "data_dir", ""), "*dev*")
+  file_pattern = os.path.join(getattr(params, "data_dir", ""), "*encoded-dev*")
   return _read_and_batch_from_files(
       file_pattern, params.batch_size, params.max_length, params.num_cpu_cores,
       shuffle=False, repeat=1)


### PR DESCRIPTION
Insert an additional tag in processed data filenames that indicates whether a file is generated in the "compile" step or "encode" step. Change filename matching pattern in dataset util to use only "encoded" files during training or evaluation. This change fixes the incorrect mixing of the 2 kinds of data in the input of training/evaluation, which causes errors.

Fixes #168 