### PR TITLE
adding tag to handle evaluations by iterations

### DIFF
--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -242,6 +242,10 @@ EVAL_ACCURACY = "eval_accuracy"
 EVAL_STOP = "eval_stop"
 
 
+# The observed accuracy of the model at a given iteration. This is only for
+# models which evaluate at certain iterations instead of epochs.
+ITERATION_EVAL_ACCURACY = "iteration_eval_accuracy"
+
 # \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 #  Model: Tags for logging topology specific information.
 # //////////////////////////////////////////////////////////////////////////////
@@ -518,6 +522,7 @@ SSD_TAGS = (
     EVAL_TARGET,
     EVAL_ACCURACY,
     EVAL_STOP,
+    ITERATION_EVAL_ACCURACY,
 )
 
 TRANSFORMER_TAGS = (

--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -244,7 +244,7 @@ EVAL_STOP = "eval_stop"
 
 # The observed accuracy of the model at a given iteration. This is only for
 # models which evaluate at certain iterations instead of epochs.
-EVAL_ITERATION_ACCURACY = "iteration_eval_accuracy"
+EVAL_ITERATION_ACCURACY = "eval_iteration_accuracy"
 
 # \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 #  Model: Tags for logging topology specific information.

--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -244,7 +244,7 @@ EVAL_STOP = "eval_stop"
 
 # The observed accuracy of the model at a given iteration. This is only for
 # models which evaluate at certain iterations instead of epochs.
-ITERATION_EVAL_ACCURACY = "iteration_eval_accuracy"
+EVAL_ITERATION_ACCURACY = "iteration_eval_accuracy"
 
 # \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 #  Model: Tags for logging topology specific information.
@@ -522,7 +522,7 @@ SSD_TAGS = (
     EVAL_TARGET,
     EVAL_ACCURACY,
     EVAL_STOP,
-    ITERATION_EVAL_ACCURACY,
+    EVAL_ITERATION_ACCURACY,
 )
 
 TRANSFORMER_TAGS = (

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.6",
+    version="0.0.7",
     author="Taylor Robie",
     author_email="taylorrobie@google.com",
     description="Tools for logging MLPerf compliance tags.",


### PR DESCRIPTION
This is to enable ssd logs to pass mlp_compliance by setting a new tag for checking for evaluations at iterations as the default evaluation tags are for evaluation at epochs.