### PR TITLE
Updated compliance logging (eval stop, bn span, warmup steps)

### DIFF
--- a/compliance/mlperf_compliance/_transformer_tags.py
+++ b/compliance/mlperf_compliance/_transformer_tags.py
@@ -21,8 +21,6 @@ from __future__ import print_function
 
 INPUT_MAX_LENGTH = "input_max_length"
 
-OPT_LR_WARMUP_STEPS = "opt_learning_rate_warmup_steps"
-
 MODEL_HP_INITIALIZER_GAIN = "model_hp_initializer_gain"
 MODEL_HP_VOCAB_SIZE = "model_hp_vocab_size"
 MODEL_HP_NUM_HIDDEN_LAYERS = "model_hp_hidden_layers"

--- a/compliance/mlperf_compliance/tags.py
+++ b/compliance/mlperf_compliance/tags.py
@@ -157,6 +157,9 @@ INPUT_ORDER = "input_order"
 # The shard size (in items) when shuffling in the input pipeline.
 INPUT_SHARD = "input_shard"
 
+# The number of samples iver which BN stats are computed for normalization during training
+INPUT_BN_SPAN = "input_bn_span"
+
 
 # --------------------------------------
 # -- Data Augmentation and Alteration --
@@ -200,6 +203,9 @@ OPT_HP_ADAM_BETA1 = "opt_hp_Adam_beta1"
 OPT_HP_ADAM_BETA2 = "opt_hp_Adam_beta2"
 OPT_HP_ADAM_EPSILON = "opt_hp_Adam_epsilon"
 
+# The number of warm-up steps (SGD).
+OPT_LR_WARMUP_STEPS = "opt_learning_rate_warmup_steps"
+
 
 # \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 #  Train: Tags for control flow during model training.
@@ -237,8 +243,8 @@ EVAL_TARGET = "eval_target"
 # The observed accuracy of the model at a given epoch.
 EVAL_ACCURACY = "eval_accuracy"
 
-# This tag should be emitted when the model has determined that it has met the
-# target quality set by the reference.
+# This tag should be emitted whenever the submission ends an evaluation pass
+# for a given set of weights.
 EVAL_STOP = "eval_stop"
 
 
@@ -313,6 +319,7 @@ GNMT_TAGS = (
 
     OPT_NAME,
     OPT_LR,
+    OPT_LR_WARMUP_STEPS,
     OPT_HP_ADAM_BETA1,
     OPT_HP_ADAM_BETA2,
     OPT_HP_ADAM_EPSILON,
@@ -466,9 +473,11 @@ RESNET_TAGS = (
     INPUT_RANDOM_FLIP,
     INPUT_RESIZE,
     INPUT_RESIZE_ASPECT_PRESERVING,
+    INPUT_BN_SPAN,
 
     OPT_NAME,
     OPT_LR,
+    OPT_LR_WARMUP_STEPS,
     OPT_MOMENTUM,
 
     TRAIN_LOOP,
@@ -509,6 +518,7 @@ SSD_TAGS = (
     INPUT_BATCH_SIZE,
     INPUT_ORDER,
     INPUT_SHARD,
+    INPUT_BN_SPAN,
 
     BACKBONE,
     FEATURE_SIZES,
@@ -530,6 +540,7 @@ SSD_TAGS = (
     OPT_LR,
     OPT_MOMENTUM,
     OPT_WEIGHT_DECAY,
+    OPT_LR_WARMUP_STEPS,
 
     TRAIN_LOOP,
     TRAIN_EPOCH,

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.9",
+    version="0.0.10",
     author="Taylor Robie",
     author_email="taylorrobie@google.com",
     description="Tools for logging MLPerf compliance tags.",


### PR DESCRIPTION
* Updated mlperf-compliance lib to version 0.0.10

* Corrected comment for EVAL_STOP

* Added OPT_LR_WARMUP_STEPS for ResNet, GNMT and SSD

* Added new tag INPUT_BN_SPAN (ResNet,SSD)