### PR TITLE
Remove subprocess and improve NCF a little bit.

### DIFF
--- a/compliance/verify_submission/mlperf_submission_helper/checks.py
+++ b/compliance/verify_submission/mlperf_submission_helper/checks.py
@@ -25,8 +25,11 @@ class SubmissionChecks(object):
     self.verify_code_dir(root_dir)
     self.verify_results_dir(root_dir)
 
-  # verify_metadata must be called after verify_dirs_and_files()
   def verify_metadata(self):
+    """Verifies the metadata.
+
+        Must be called after verify_dirs_and_files()
+    """
     self.verify_submission_metadata()
     self.verify_result_entry_metadata()
 
@@ -118,14 +121,53 @@ class SubmissionChecks(object):
                 result_name, [None for j in range(result_num)])
             division = self.result_entry_meta[entry_name].get('division')
             log_path = os.path.join(result_dir, log_file_name)
-            dt = self.verify_and_extract_time(log_path, division, result_name)
-            self.result_meta[entry_name][result_name][i] = dt
+            dt, start_time = self.verify_and_extract_time(log_path,
+                                                          division,
+                                                          result_name)
+            self._add_result(self.result_meta[entry_name][result_name],
+                             i,
+                             dt,
+                             start_time)
     except Exception as e:
       self.report.add_error('Unable to verify results dir: {}'.format(str(e)))
 
+  def _add_result(self, dict_entry, entry, dt, start_time):
+    """Adds a result to the dictionary.
+
+    Args:
+      dict_entry: main dict to add entry
+      entry: slot for this entry (likely an integer)
+      dt: the timing for the entry
+      start_time: when the entry started unix time float
+    """
+    time_entry = {}
+    time_entry['dt'] = dt
+    time_entry['start_time'] = start_time
+    dict_entry[entry] = time_entry
+
+  def _sorted_results(self, results_dicts):
+    """Sorts dict of results based on log start_time.
+
+    Sorts the results and returns an array with only the values but sorted
+    by oldest value first.value
+
+    Args:
+      results_dicts: List of result dicts
+
+    Returns:
+      List of only the time but sorted oldest first.
+    """
+    print('results dicts:', results_dicts)
+    sorted_dict = sorted(results_dicts, key=lambda k: k['start_time'])
+    results = []
+    for entry in sorted_dict:
+      results.append(entry['dt'])
+    return results
+
   def verify_submission_metadata(self):
     subm_meta_keys = self.submission_meta.keys()
-    different_keys = set(subm_meta_keys).difference(set(constants.SUBM_META_PROPS))
+    different_keys = set(subm_meta_keys).difference(
+        set(constants.SUBM_META_PROPS))
     if different_keys:
       self.report.add_failed_check(
           'Keys in submission metadata do not match expected: ' +
@@ -174,6 +216,8 @@ class SubmissionChecks(object):
                                     entry_name, benchmark_name))
           results[entry_name][benchmark_name] = None
           continue
+        # Turns dict into list or results oldest first
+        benchmark_results = self._sorted_results(benchmark_results)
         # special treatment for the NCF results
         if benchmark_name == 'ncf':
           possible_results = benchmark_results
@@ -190,10 +234,13 @@ class SubmissionChecks(object):
           if len(benchmark_results) != 50:
             raise Exception('NCF does not have 50 good results')
           if len(possible_results) != 100:
-            raise Exception('NCF does not have 100 good results:{}'.
-                            format(len(possible_results)))
+            raise Exception('NCF does not have 100 good results:{}'.format(
+                len(possible_results)))
 
         benchmark_results = sorted(benchmark_results)
+        print('benchmark_name:{}|{} results{}'.format(benchmark_name,
+                                                      entry_name,
+                                                      benchmark_results))
         del benchmark_results[0]
         del benchmark_results[-1]
         result_val = (
@@ -206,13 +253,15 @@ class SubmissionChecks(object):
     """Get the compliance level of the output file."""
     print('Running Compliance Check on {}'.format(filename))
     print('#' * 80)
-    status, dt, qual, target = mlp_compliance.l2_check_file(filename)
+    start_time, status, dt, qual, target = mlp_compliance.l2_check_file_w_starttime(
+        filename)
     print('#' * 80)
 
     if status:
       level = '2'
     else:
-      status, dt, qual, target = mlp_compliance.l1_check_file(filename)
+      start_time, status, dt, qual, target = mlp_compliance.l1_check_file_w_starttime(
+          filename)
       print('#' * 80)
       if status:
         level = '1'
@@ -220,7 +269,7 @@ class SubmissionChecks(object):
         level = '0'
 
     success = status and qual and target and qual >= target
-    return level, dt, qual, success
+    return start_time, level, dt, qual, success
 
   def verify_and_extract_time(self, log_file, division, result_name):
     """Verifies and result and returns timing.
@@ -240,20 +289,21 @@ class SubmissionChecks(object):
       out expected compliance level.
 
     """
-    expected_level = constants.DIVISION_COMPLIANCE_CHECK_LEVEL.get(division,
-                                                                   None)
+    expected_level = constants.DIVISION_COMPLIANCE_CHECK_LEVEL.get(
+        division, None)
     print(result_name)
     if expected_level is None:
       raise Exception('Unknown division: {}'.format(division))
-    level, dt, _, success = self.get_compliance(log_file)
+    start_time, level, dt, _, success = self.get_compliance(log_file)
+    print(float(start_time))
     if int(level) != expected_level:
-      raise Exception('Error Level {} does not match needed level {}:{}'.
-                      format(level, expected_level, log_file))
+      raise Exception('Error Level {} does not match needed level {}:{}'.format(
+          level, expected_level, log_file))
 
     # Sets failure to converge to "infinite time" per the rules
     if success and dt:
-      return dt
+      return dt, start_time
     else:
-      print('Result was not a success set to INFINITE_TIME({})'.
-            format(INFINITE_TIME))
-      return INFINITE_TIME
+      print('Result was not a success set to INFINITE_TIME({})'.format(
+          INFINITE_TIME))
+      return INFINITE_TIME, start_time

--- a/compliance/verify_submission/mlperf_submission_helper/checks.py
+++ b/compliance/verify_submission/mlperf_submission_helper/checks.py
@@ -1,202 +1,248 @@
+"""Checks to run against a submission."""
+from __future__ import print_function
+
 import json
 import os
-import subprocess
 
-from constants import *
+import constants
+import mlp_compliance.mlp_compliance as mlp_compliance
 import report as subm_report
+
+INFINITE_TIME = 9999999999.99
 
 
 class SubmissionChecks(object):
+  """Submission checks."""
 
-    def __init__(self):
-       self.report = subm_report.SubmissionReport()
-       self.submission_meta = {}
-       self.result_meta = {}
-       self.result_entry_meta = {}
+  def __init__(self):
+    self.report = subm_report.SubmissionReport()
+    self.submission_meta = {}
+    self.result_meta = {}
+    self.result_entry_meta = {}
 
-    def verify_dirs_and_files(self, root_dir):
-        self.verify_root_dir(root_dir)
-        self.verify_code_dir(root_dir)
-        self.verify_results_dir(root_dir)
+  def verify_dirs_and_files(self, root_dir):
+    self.verify_root_dir(root_dir)
+    self.verify_code_dir(root_dir)
+    self.verify_results_dir(root_dir)
 
-    # verify_metadata must be called after verify_dirs_and_files()
-    def verify_metadata(self):
-        self.verify_submission_metadata()
-        self.verify_result_entry_metadata()
+  # verify_metadata must be called after verify_dirs_and_files()
+  def verify_metadata(self):
+    self.verify_submission_metadata()
+    self.verify_result_entry_metadata()
 
-    def exists(self, path, is_dir=False):
-        exists_fn = os.path.isdir if is_dir else os.path.isfile
-        if exists_fn(path):
-            self.report.add_passed_check("Path exists: {}".format(path))
-        else:
-            self.report.add_failed_check("Path not found: {}".format(path))
+  def exists(self, path, is_dir=False):
+    exists_fn = os.path.isdir if is_dir else os.path.isfile
+    if exists_fn(path):
+      self.report.add_passed_check('Path exists: {}'.format(path))
+    else:
+      self.report.add_failed_check('Path not found: {}'.format(path))
 
-    def name_in(self, path, ref_list):
-        basename = os.path.basename(path)
-        if basename in ref_list:
-            self.report.add_passed_check("{} name is in {}.".format(path, ref_list))
-        else:
-            self.report.add_failed_check("{} name not in {}.".format(path, ref_list))
+  def name_in(self, path, ref_list):
+    basename = os.path.basename(path)
+    if basename in ref_list:
+      self.report.add_passed_check('{} name is in {}.'.format(path, ref_list))
+    else:
+      self.report.add_failed_check('{} name not in {}.'.format(path, ref_list))
 
-    def keys_match(self, keys, ref_keys, context=""):
-        different_keys = set(keys).difference(set(ref_keys))
-        if different_keys:
-            self.report.add_failed_check(
-                    "Keys in {} do not match expected: ".format(context) +
-                    "unmatched keys: {}".format(list(different_keys)))
-        else:
-            self.report.add_passed_check(
-                    "Keys in {} match expected.".format(context))
+  def keys_match(self, keys, ref_keys, context=''):
+    different_keys = set(keys).difference(set(ref_keys))
+    if different_keys:
+      self.report.add_failed_check('Keys in {} do not match expected: '.format(
+          context) + 'unmatched keys: {}'.format(list(different_keys)))
+    else:
+      self.report.add_passed_check('Keys in {} match expected.'.format(context))
 
-    def verify_root_dir(self, root_dir):
-        result_dir = os.path.join(root_dir, "results")
-        code_dir = os.path.join(root_dir, "code")
-        submission_meta_file = os.path.join(root_dir, "submission.json")
+  def verify_root_dir(self, root_dir):
+    result_dir = os.path.join(root_dir, 'results')
+    code_dir = os.path.join(root_dir, 'code')
+    submission_meta_file = os.path.join(root_dir, 'submission.json')
 
-        self.exists(result_dir, is_dir=True)
-        self.exists(code_dir, is_dir=True)
-        self.exists(submission_meta_file, is_dir=False)
+    self.exists(result_dir, is_dir=True)
+    self.exists(code_dir, is_dir=True)
+    self.exists(submission_meta_file, is_dir=False)
 
+    try:
+      with open(submission_meta_file) as f:
+        self.submission_meta = json.load(f)
+    except Exception as e:
+      self.report.add_error('Unable to parse submission meatadata: {}'.format(
+          str(e)))
+
+  def verify_code_dir(self, root_dir):
+    code_root_dir = os.path.join(root_dir, 'code')
+    try:
+      for code_name in os.listdir(code_root_dir):
+        code_dir = os.path.join(code_root_dir, code_name)
+        if not os.path.isdir(code_dir):
+          continue
+        self.name_in(code_dir, constants.BENCHMARK_NAMES + ['shared'])
+        if code_name in constants.BENCHMARK_NAMES:
+          self.exists(os.path.join(code_dir, 'README.md'))
+          self.exists(os.path.join(code_dir, 'preproc_dataset.sh'))
+    except Exception as e:
+      self.report.add_error('Unable to verify code dir: {}'.format(str(e)))
+
+  def verify_results_dir(self, root_dir):
+    code_root_dir = os.path.join(root_dir, 'code')
+    result_root_dir = os.path.join(root_dir, 'results')
+    try:
+      for entry_name in os.listdir(result_root_dir):
+        entry_dir = os.path.join(result_root_dir, entry_name)
+        if not os.path.isdir(entry_dir):
+          continue
+        entry_meta_file = os.path.join(entry_dir, 'entry.json')
         try:
-            with open(submission_meta_file) as f:
-                self.submission_meta = json.load(f)
+          with open(entry_meta_file) as f:
+            self.result_entry_meta[entry_name] = json.load(f)
         except Exception as e:
-            self.report.add_error(
-                    "Unable to parse submission meatadata: {}".format(str(e)))
+          self.report.add_error(
+              'Unable to parse result entry metadata: {}'.format(str(e)))
+        self.exists(entry_meta_file)
+        for result_name in os.listdir(entry_dir):
+          result_dir = os.path.join(entry_dir, result_name)
+          if not os.path.isdir(result_dir):
+            continue
+          self.name_in(result_dir, constants.BENCHMARK_NAMES)
+          self.exists(
+              os.path.join(code_root_dir, result_name,
+                           'setup_' + entry_name + '.sh'))
+          self.exists(
+              os.path.join(code_root_dir, result_name,
+                           'run_and_time_' + entry_name + '.sh'))
+          result_num = constants.REQUIRED_RESULT_NUM.get(result_name, 0)
+          for i in range(result_num):
+            log_file_name = 'result_' + str(i) + '.txt'
+            self.exists(os.path.join(result_dir, log_file_name))
+            self.result_meta.setdefault(entry_name, {})
+            self.result_meta[entry_name].setdefault(
+                result_name, [None for j in range(result_num)])
+            division = self.result_entry_meta[entry_name].get('division')
+            log_path = os.path.join(result_dir, log_file_name)
+            dt = self.verify_and_extract_time(log_path, division, result_name)
+            self.result_meta[entry_name][result_name][i] = dt
+    except Exception as e:
+      self.report.add_error('Unable to verify results dir: {}'.format(str(e)))
 
-    def verify_code_dir(self, root_dir):
-        code_root_dir = os.path.join(root_dir, "code")
-        try:
-            for code_name in os.listdir(code_root_dir):
-                code_dir = os.path.join(code_root_dir, code_name)
-                if not os.path.isdir(code_dir):
-                    continue
-                self.name_in(code_dir, BENCHMARK_NAMES + ["shared"])
-                if code_name in BENCHMARK_NAMES:
-                    self.exists(os.path.join(code_dir, "README.md"))
-                    self.exists(os.path.join(code_dir, "preproc_dataset.sh"))
-        except Exception as e:
-            self.report.add_error(
-                    "Unable to verify code dir: {}".format(str(e)))
+  def verify_submission_metadata(self):
+    subm_meta_keys = self.submission_meta.keys()
+    different_keys = set(subm_meta_keys).difference(set(constants.SUBM_META_PROPS))
+    if different_keys:
+      self.report.add_failed_check(
+          'Keys in submission metadata do not match expected: ' +
+          'unmatched keys: {}'.format(list(different_keys)))
+    else:
+      self.report.add_passed_check(
+          'Keys in submission metadata match expected.')
 
-    def verify_results_dir(self, root_dir):
-        code_root_dir = os.path.join(root_dir, "code")
-        result_root_dir = os.path.join(root_dir, "results")
-        try:
-            for entry_name in os.listdir(result_root_dir):
-                entry_dir = os.path.join(result_root_dir, entry_name)
-                if not os.path.isdir(entry_dir):
-                    continue
-                entry_meta_file = os.path.join(entry_dir, "entry.json")
-                try:
-                    with open(entry_meta_file) as f:
-                        self.result_entry_meta[entry_name] = json.load(f)
-                except Exception as e:
-                    self.report.add_error(
-                            "Unable to parse result entry metadata: {}".format(str(e)))
-                self.exists(entry_meta_file)
-                for result_name in os.listdir(entry_dir):
-                    result_dir = os.path.join(entry_dir, result_name)
-                    if not os.path.isdir(result_dir):
-                        continue
-                    self.name_in(result_dir, BENCHMARK_NAMES)
-                    self.exists(os.path.join(code_root_dir, result_name,
-                            "setup_" + entry_name + ".sh"))
-                    self.exists(os.path.join(code_root_dir, result_name,
-                            "run_and_time_" + entry_name + ".sh"))
-                    result_num = REQUIRED_RESULT_NUM.get(result_name, 0)
-                    for i in range(result_num):
-                        log_file_name = "result_" + str(i) + ".txt"
-                        self.exists(os.path.join(result_dir, log_file_name))
-                        self.result_meta.setdefault(entry_name, {})
-                        self.result_meta[entry_name].setdefault(
-                                result_name, [None for j in range(result_num)])
-                        division = self.result_entry_meta[entry_name].get("division")
-                        self.result_meta[entry_name][result_name][i] = \
-                                self.verify_and_extract_time(
-                                os.path.join(result_dir, log_file_name), division)
-        except Exception as e:
-            self.report.add_error("Unable to verify results dir: {}".format(str(e)))
+  def verify_result_entry_metadata(self):
+    for entry_name in self.result_entry_meta:
+      entry_meta = self.result_entry_meta[entry_name]
+      entry_meta_keys = entry_meta.keys()
+      self.keys_match(
+          entry_meta_keys,
+          constants.ENTRY_META_PROPS,
+          context='entry {} metadata'.format(entry_name))
+      try:
+        for node_meta in entry_meta['nodes']:
+          node_meta_keys = node_meta.keys()
+          self.keys_match(
+              node_meta_keys,
+              constants.NODE_META_PROPS,
+              context='entry {} node metadata'.format(entry_name))
+      except Exception as e:
+        self.report.add_error(
+            'Unable to verify node metadata for entry {}: {}'.format(
+                entry_name, str(e)))
 
-    def verify_submission_metadata(self):
-        subm_meta_keys = self.submission_meta.keys()
-        different_keys = set(subm_meta_keys).difference(set(SUBM_META_PROPS))
-        if different_keys:
-            self.report.add_failed_check(
-                    "Keys in submission metadata do not match expected: " +
-                    "unmatched keys: {}".format(list(different_keys)))
-        else:
-            self.report.add_passed_check(
-                    "Keys in submission metadata match expected.")
+  def compile_results(self):
+    results = {}
+    for entry_name in self.result_meta:
+      results.setdefault(entry_name, {})
+      for key in constants.RESULT_SUBM_META_COLUMNS:
+        results[entry_name][key] = self.submission_meta[key]
+      for key in constants.RESULT_ENTRY_META_COLUMNS:
+        results[entry_name][key] = self.result_entry_meta[entry_name][key]
+      for benchmark_name in constants.BENCHMARK_NAMES:
+        benchmark_results = self.result_meta[entry_name].get(
+            benchmark_name, None)
+        if not benchmark_results:
+          results[entry_name][benchmark_name] = None
+          continue
+        if not all(benchmark_results):
+          self.report.add_error('Benchmark results contain None values. ' +
+                                'entry: {}, benchmark name: {}'.format(
+                                    entry_name, benchmark_name))
+          results[entry_name][benchmark_name] = None
+          continue
+        # special treatment for the NCF results
+        if benchmark_name == 'ncf':
+          possible_results = benchmark_results
+          benchmark_results = []
+          for pr in possible_results:
+            # Skips results that were failures to converge, which are set to
+            # INFINITE_TIME
+            if pr != INFINITE_TIME:
+              benchmark_results.append(pr)
+            # Stops after it finds 50 results, which may not be the first
+            # 50 by date unless they are sorted earlier.
+            if len(benchmark_results) == 50:
+              break
+          if len(benchmark_results) != 50:
+            raise Exception('NCF does not have 50 good results')
+          if len(possible_results) != 100:
+            raise Exception('NCF does not have 100 good results:{}'.
+                            format(len(possible_results)))
 
-    def verify_result_entry_metadata(self):
-        for entry_name in self.result_entry_meta:
-            entry_meta = self.result_entry_meta[entry_name]
-            entry_meta_keys = entry_meta.keys()
-            self.keys_match(entry_meta_keys, ENTRY_META_PROPS,
-                    context="entry {} metadata".format(entry_name))
-            try:
-                for node_meta in entry_meta["nodes"]:
-                    node_meta_keys = node_meta.keys()
-                    self.keys_match(node_meta_keys, NODE_META_PROPS,
-                            context="entry {} node metadata".format(entry_name))
-            except Exception as e:
-                self.report.add_error(
-                        "Unable to verify node metadata for entry {}: {}".format(
-                        entry_name, str(e)))
+        benchmark_results = sorted(benchmark_results)
+        del benchmark_results[0]
+        del benchmark_results[-1]
+        result_val = (
+            float(sum(benchmark_results)) / len(benchmark_results) /
+            constants.REFERENCE_RESULTS[benchmark_name])
+        results[entry_name][benchmark_name] = result_val
+    self.report.set_results(results)
 
-    def compile_results(self):
-        results = {}
-        for entry_name in self.result_meta:
-            results.setdefault(entry_name, {})
-            for key in RESULT_SUBM_META_COLUMNS:
-                results[entry_name][key] = self.submission_meta[key]
-            for key in RESULT_ENTRY_META_COLUMNS:
-                results[entry_name][key] = self.result_entry_meta[entry_name][key]
-            for benchmark_name in BENCHMARK_NAMES:
-                benchmark_results = self.result_meta[entry_name].get(benchmark_name, None)
-                if not benchmark_results:
-                    results[entry_name][benchmark_name] = None
-                    continue
-                if not all(benchmark_results):
-                    self.report.add_error("Benchmark results contain None values. " +
-                            "entry: {}, benchmark name: {}".format(entry_name, benchmark_name))
-                    results[entry_name][benchmark_name] = None
-                    continue
-                # special treatment for the NCF results
-                if benchmark_name == "ncf":
-                    possible_results = benchmark_results
-                    benchmark_results = []
-                    for pr in possible_results:
-                        if pr is not None:
-                            benchmark_results.append(pr)
-                        if len(benchmark_results) == 50:
-                            break
-                benchmark_results = sorted(benchmark_results)
-                del benchmark_results[0]
-                del benchmark_results[-1]
-                result_val = (float(sum(benchmark_results)) /
-                        len(benchmark_results) / REFERENCE_RESULTS[benchmark_name])
-                results[entry_name][benchmark_name] = result_val
-        self.report.set_results(results)
+  def get_compliance(self, filename):
+    """Get the compliance level of the output file."""
+    if filename.startswith('/'):
+      output_file = filename
+    else:
+      output_file = os.path.join(self.workspace, filename)
 
-    # use submodule mlp_compliance (https://github.com/bitfort/mlp_compliance)
-    def verify_and_extract_time(self, log_file, division):
-        level = DIVISION_COMPLIANCE_CHECK_LEVEL.get(division, None)
-        if level is None:
-            raise Exception("Unknown division: {}".format(division))
-        mlp_compliance_script = os.path.join(
-                os.path.dirname(__file__), "mlp_compliance/mlp_compliance.py")
-        output_str = subprocess.check_output(
-                ["python", mlp_compliance_script, "--level", str(level), log_file])
-        success_flag = False
-        result_time = None
-        for line in output_str.split("\n"):
-            if line.startswith("SUCCESS"):
-                success_flag = True
-            if line.startswith("Measured time:"):
-                result_time = float(line.lstrip("Measured time:").strip())
-        if success_flag and result_time is not None:
-            return result_time
-        else:
-            raise Exception("Result verification failed: {}".format(log_file))
+    print('Running Compliance Check on {}'.format(output_file))
+    print('#' * 80)
+    status, dt, qual, target = mlp_compliance.l2_check_file(output_file)
+    print('#' * 80)
+
+    if status:
+      level = '2'
+    else:
+      status, dt, qual, target = mlp_compliance.l1_check_file(output_file)
+      print('#' * 80)
+      if status:
+        level = '1'
+      else:
+        level = '0'
+
+    success = status and qual and target and qual >= target
+    return level, dt, qual, success
+
+  # use submodule mlp_compliance (https://github.com/bitfort/mlp_compliance)
+  def verify_and_extract_time(self, log_file, division, result_name):
+    expected_level = constants.DIVISION_COMPLIANCE_CHECK_LEVEL.get(division,
+                                                                   None)
+    print(result_name)
+    if expected_level is None:
+      raise Exception('Unknown division: {}'.format(division))
+    level, dt, _, success = self.get_compliance(log_file)
+    if int(level) != expected_level:
+      print('Error Level {} does not match needed level {}:{}'.
+            format(level, expected_level, log_file))
+
+    # Sets failure to converge to "infinite time" per the rules
+    if success and dt:
+      return dt
+    else:
+      print('Result was not a success set to INFINITE_TIME({})'.
+            format(INFINITE_TIME))
+      return INFINITE_TIME

--- a/compliance/verify_submission/mlperf_submission_helper/checks.py
+++ b/compliance/verify_submission/mlperf_submission_helper/checks.py
@@ -236,7 +236,7 @@ class SubmissionChecks(object):
       raise Exception('Unknown division: {}'.format(division))
     level, dt, _, success = self.get_compliance(log_file)
     if int(level) != expected_level:
-      print('Error Level {} does not match needed level {}:{}'.
+      raise Exception('Error Level {} does not match needed level {}:{}'.
             format(level, expected_level, log_file))
 
     # Sets failure to converge to "infinite time" per the rules

--- a/compliance/verify_submission/mlperf_submission_helper/checks_test.py
+++ b/compliance/verify_submission/mlperf_submission_helper/checks_test.py
@@ -12,19 +12,53 @@ class TestChecks(unittest.TestCase):
   def test_verify_and_extract_time_not_success(self):
     """Tests extract the cpu model name."""
     smi_test = 'unittest_files/10_mixed_results/result_7.txt'
-    smi_test = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                            smi_test)
+    smi_test = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), smi_test)
     sub_check = checks.SubmissionChecks()
-    dt = sub_check.verify_and_extract_time(smi_test, 'closed', 'ncf')
+    dt, start_time = sub_check.verify_and_extract_time(smi_test, 'closed',
+                                                       'ncf')
     self.assertEqual(dt, checks.INFINITE_TIME)
+    self.assertEqual(start_time, 1541638706.6702664)
 
   def test_verify_and_extract_time_success(self):
     """Tests extract the cpu model name."""
     smi_test = 'unittest_files/10_mixed_results/result_2.txt'
-    smi_test = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                            smi_test)
+    smi_test = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), smi_test)
     sub_check = checks.SubmissionChecks()
-    dt = sub_check.verify_and_extract_time(smi_test, 'closed', 'ncf')
+    dt, start_time = sub_check.verify_and_extract_time(smi_test, 'closed',
+                                                       'ncf')
     self.assertEqual(dt, 210.3895456790924)
+    self.assertEqual(start_time, 1541635651.95072)
 
+  def test_add_result(self):
+    """Tests adding result to metadata dict."""
+    sub_check = checks.SubmissionChecks()
+    meta = {}
+    meta['entry_name'] = {}
+    meta['entry_name']['result_name'] = {}
+    sub_check._add_result(meta['entry_name']['result_name'],
+                          1,
+                          10.11,
+                          343434343.91)
+    result = meta['entry_name']['result_name'][1]
+    self.assertEqual(result['dt'], 10.11)
+    self.assertEqual(result['start_time'], 343434343.91)
 
+  def test_sort_results(self):
+    """tests sorting results."""
+    results_dict = []
+    results_dict.append(self._create_result_dict(23, 1.993))
+    results_dict.append(self._create_result_dict(55, 19.993))
+    results_dict.append(self._create_result_dict(1, 0.993))
+    results_dict.append(self._create_result_dict(99, 999991.993))
+
+    sub_check = checks.SubmissionChecks()
+    sorted_results = sub_check._sorted_results(results_dict)
+    self.assertEqual(sorted_results, [1, 23, 55, 99])
+
+  def _create_result_dict(self, dt, start_time):
+    result = {}
+    result['dt'] = dt
+    result['start_time'] = start_time
+    return result

--- a/compliance/verify_submission/mlperf_submission_helper/checks_test.py
+++ b/compliance/verify_submission/mlperf_submission_helper/checks_test.py
@@ -1,0 +1,30 @@
+"""Tests checks module."""
+from __future__ import print_function
+
+import os
+import unittest
+
+import checks
+
+
+class TestChecks(unittest.TestCase):
+
+  def test_verify_and_extract_time_not_success(self):
+    """Tests extract the cpu model name."""
+    smi_test = 'unittest_files/10_mixed_results/result_7.txt'
+    smi_test = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            smi_test)
+    sub_check = checks.SubmissionChecks()
+    dt = sub_check.verify_and_extract_time(smi_test, 'closed', 'ncf')
+    self.assertEqual(dt, checks.INFINITE_TIME)
+
+  def test_verify_and_extract_time_success(self):
+    """Tests extract the cpu model name."""
+    smi_test = 'unittest_files/10_mixed_results/result_2.txt'
+    smi_test = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            smi_test)
+    sub_check = checks.SubmissionChecks()
+    dt = sub_check.verify_and_extract_time(smi_test, 'closed', 'ncf')
+    self.assertEqual(dt, 210.3895456790924)
+
+

--- a/compliance/verify_submission/mlperf_submission_helper/constants.py
+++ b/compliance/verify_submission/mlperf_submission_helper/constants.py
@@ -1,43 +1,19 @@
+"""Constants used throughput the library."""
 BENCHMARK_NAMES = [
-    "resnet",
-    "ssd",
-    "maskrcnn",
-    "transformer",
-    "gnmt",
-    "ncf",
-    "minigo"
+    "resnet", "ssd", "maskrcnn", "transformer", "gnmt", "ncf", "minigo"
 ]
-SUBM_META_PROPS = [
-    "org",
-    "poc_email"
-]
+SUBM_META_PROPS = ["org", "poc_email"]
 ENTRY_META_PROPS = [
-    "division",
-    "status",
-    "hardware",
-    "framework",
-    "power",
-    "notes",
-    "interconnect",
-    "nodes",
-    "os",
-    "libraries",
-    "compilers"
+    "division", "status", "hardware", "framework", "interconnect", "nodes",
+    "os", "libraries", "compilers"
+    # Not required
+    # "power"
+    # "notes",
 ]
 NODE_META_PROPS = [
-    "num_nodes",
-    "cpu",
-    "num_cores",
-    "num_vcpus",
-    "accelerator",
-    "num_accelerators",
-    "sys_mem_size",
-    "sys_storage_type",
-    "sys_storage_size",
-    "cpu_accel_interconnect",
-    "network_card",
-    "num_network_cards",
-    "notes"
+    "num_nodes", "cpu", "num_cores", "num_vcpus", "accelerator",
+    "num_accelerators", "sys_mem_size", "sys_storage_type", "sys_storage_size",
+    "cpu_accel_interconnect", "network_card", "num_network_cards", "notes"
 ]
 REQUIRED_RESULT_NUM = {
     "resnet": 5,
@@ -63,18 +39,12 @@ RESULT_SUBM_META_COLUMNS = [
     "org",
 ]
 RESULT_ENTRY_META_COLUMNS = [
-    "division",
-    "status",
-    "hardware",
-    "framework",
-    "power",
-    "notes"
+    "division", "status", "hardware", "framework",
+    # not required
+    # "power", "notes"
 ]
 
-DIVISION_COMPLIANCE_CHECK_LEVEL = {
-    "open": 1,
-    "closed": 2
-}
+DIVISION_COMPLIANCE_CHECK_LEVEL = {"open": 1, "closed": 2}
 
 # check result status
 SUCCESS = "success"

--- a/compliance/verify_submission/mlperf_submission_helper/crypto.py
+++ b/compliance/verify_submission/mlperf_submission_helper/crypto.py
@@ -8,101 +8,102 @@ from Cryptodome.Cipher import AES, PKCS1_OAEP
 
 
 def encrypt_file(public_key, src_file, dest_file):
-    try:
-        with open(src_file) as f:
-            rsa_key = RSA.import_key(open(public_key).read())
-            session_key = get_random_bytes(16)
-            # Encrypt session key
-            cipher_rsa = PKCS1_OAEP.new(rsa_key)
-            encrypted_session_key = cipher_rsa.encrypt(session_key)
-            # Encrypt data
-            cipher_aes = AES.new(session_key, AES.MODE_EAX)
-            ciphertext, tag = cipher_aes.encrypt_and_digest(f.read().encode("utf-8"))
-    except Exception as e:
-        print("Unable to encrypt file: {}".format(src_file))
-        raise e
+  try:
+    with open(src_file) as f:
+      rsa_key = RSA.import_key(open(public_key).read())
+      session_key = get_random_bytes(16)
+      # Encrypt session key
+      cipher_rsa = PKCS1_OAEP.new(rsa_key)
+      encrypted_session_key = cipher_rsa.encrypt(session_key)
+      # Encrypt data
+      cipher_aes = AES.new(session_key, AES.MODE_EAX)
+      ciphertext, tag = cipher_aes.encrypt_and_digest(f.read().encode("utf-8"))
+  except Exception as e:
+    print("Unable to encrypt file: {}".format(src_file))
+    raise e
 
-    try:
-        with open(dest_file, "wb") as f:
-            for x in (encrypted_session_key, cipher_aes.nonce, tag, ciphertext):
-                f.write(x)
-    except Exception as e:
-        print("Unable to write output file {}".format(dest_file))
-        raise e
+  try:
+    with open(dest_file, "wb") as f:
+      for x in (encrypted_session_key, cipher_aes.nonce, tag, ciphertext):
+        f.write(x)
+  except Exception as e:
+    print("Unable to write output file {}".format(dest_file))
+    raise e
 
 
 def decrypt_file(private_key, src_file, dest_file):
-    try:
-        with open(src_file, "rb") as f:
-            rsa_key = RSA.import_key(open(private_key).read())
-            encrypted_session_key = f.read(rsa_key.size_in_bytes())
-            nonce = f.read(16)
-            tag = f.read(16)
-            ciphertext = f.read(-1)
+  try:
+    with open(src_file, "rb") as f:
+      rsa_key = RSA.import_key(open(private_key).read())
+      encrypted_session_key = f.read(rsa_key.size_in_bytes())
+      nonce = f.read(16)
+      tag = f.read(16)
+      ciphertext = f.read(-1)
 
-            # Decrypt session key
-            cipher_rsa = PKCS1_OAEP.new(rsa_key)
-            session_key = cipher_rsa.decrypt(encrypted_session_key)
-            # Decrypt data
-            cipher_aes = AES.new(session_key, AES.MODE_EAX, nonce)
-            data = cipher_aes.decrypt_and_verify(ciphertext, tag)
-            data = data.decode("utf-8")
-    except Exception as e:
-        print("Unable to decrypt file: {}".format(src_file))
-        raise e
+      # Decrypt session key
+      cipher_rsa = PKCS1_OAEP.new(rsa_key)
+      session_key = cipher_rsa.decrypt(encrypted_session_key)
+      # Decrypt data
+      cipher_aes = AES.new(session_key, AES.MODE_EAX, nonce)
+      data = cipher_aes.decrypt_and_verify(ciphertext, tag)
+      data = data.decode("utf-8")
+  except Exception as e:
+    print("Unable to decrypt file: {}".format(src_file))
+    raise e
 
-    try:
-        with open(dest_file, "w") as f:
-            f.write(data)
-    except Exception as e:
-        print("Unable to write output file: {}".format(dest_file))
-        raise e
+  try:
+    with open(dest_file, "w") as f:
+      f.write(data)
+  except Exception as e:
+    print("Unable to write output file: {}".format(dest_file))
+    raise e
 
 
 def encrypt_submission(key, src_dir, dest_dir):
-    if os.path.isdir(dest_dir):
-        raise Exception("Output directory already exists.")
-    os.mkdir(dest_dir, mode=0o755)
-    for root, dirs, files in os.walk(src_dir):
-        # identify result files and encrypt, else directly copy
-        if fnmatch.fnmatch(root, os.path.join(src_dir, "results", "*", "*")):
-            for f in files:
-                from_file = os.path.join(root, f)
-                to_file = from_file.replace(src_dir.rstrip(os.sep),
-                        dest_dir.rstrip(os.sep), 1)
-                encrypt_file(key, from_file, to_file)
-        else:
-            for d in dirs:
-                from_dir = os.path.join(root, d)
-                to_dir = from_dir.replace(src_dir.rstrip(os.sep),
-                        dest_dir.rstrip(os.sep), 1)
-                os.mkdir(to_dir, mode=0o755)
-            for f in files:
-                from_file = os.path.join(root, f)
-                to_file = from_file.replace(src_dir.rstrip(os.sep),
-                        dest_dir.rstrip(os.sep), 1)
-                shutil.copyfile(from_file, to_file)
+  if os.path.isdir(dest_dir):
+    raise Exception("Output directory already exists.")
+  os.mkdir(dest_dir, mode=0o755)
+  for root, dirs, files in os.walk(src_dir):
+    # identify result files and encrypt, else directly copy
+    if fnmatch.fnmatch(root, os.path.join(src_dir, "results", "*", "*")):
+      for f in files:
+        from_file = os.path.join(root, f)
+        to_file = from_file.replace(
+            src_dir.rstrip(os.sep), dest_dir.rstrip(os.sep), 1)
+        encrypt_file(key, from_file, to_file)
+    else:
+      for d in dirs:
+        from_dir = os.path.join(root, d)
+        to_dir = from_dir.replace(
+            src_dir.rstrip(os.sep), dest_dir.rstrip(os.sep), 1)
+        os.mkdir(to_dir, mode=0o755)
+      for f in files:
+        from_file = os.path.join(root, f)
+        to_file = from_file.replace(
+            src_dir.rstrip(os.sep), dest_dir.rstrip(os.sep), 1)
+        shutil.copyfile(from_file, to_file)
+
 
 def decrypt_submission(key, src_dir, dest_dir):
-    if os.path.isdir(dest_dir):
-        raise Exception("Output directory already exists.")
-    os.mkdir(dest_dir, mode=0o755)
-    for root, dirs, files in os.walk(src_dir):
-        # identify result files and encrypt, else directly copy
-        if fnmatch.fnmatch(root, os.path.join(src_dir, "results", "*", "*")):
-            for f in files:
-                from_file = os.path.join(root, f)
-                to_file = from_file.replace(src_dir.rstrip(os.sep),
-                        dest_dir.rstrip(os.sep), 1)
-                decrypt_file(key, from_file, to_file)
-        else:
-            for d in dirs:
-                from_dir = os.path.join(root, d)
-                to_dir = from_dir.replace(src_dir.rstrip(os.sep),
-                        dest_dir.rstrip(os.sep), 1)
-                os.mkdir(to_dir, mode=0o755)
-            for f in files:
-                from_file = os.path.join(root, f)
-                to_file = from_file.replace(src_dir.rstrip(os.sep),
-                        dest_dir.rstrip(os.sep), 1)
-                shutil.copyfile(from_file, to_file)
+  if os.path.isdir(dest_dir):
+    raise Exception("Output directory already exists.")
+  os.mkdir(dest_dir, mode=0o755)
+  for root, dirs, files in os.walk(src_dir):
+    # identify result files and encrypt, else directly copy
+    if fnmatch.fnmatch(root, os.path.join(src_dir, "results", "*", "*")):
+      for f in files:
+        from_file = os.path.join(root, f)
+        to_file = from_file.replace(
+            src_dir.rstrip(os.sep), dest_dir.rstrip(os.sep), 1)
+        decrypt_file(key, from_file, to_file)
+    else:
+      for d in dirs:
+        from_dir = os.path.join(root, d)
+        to_dir = from_dir.replace(
+            src_dir.rstrip(os.sep), dest_dir.rstrip(os.sep), 1)
+        os.mkdir(to_dir, mode=0o755)
+      for f in files:
+        from_file = os.path.join(root, f)
+        to_file = from_file.replace(
+            src_dir.rstrip(os.sep), dest_dir.rstrip(os.sep), 1)
+        shutil.copyfile(from_file, to_file)

--- a/compliance/verify_submission/mlperf_submission_helper/report.py
+++ b/compliance/verify_submission/mlperf_submission_helper/report.py
@@ -4,72 +4,60 @@ from constants import *
 
 
 class SubmissionReport(object):
-    """SubmissionReport stores submission info and produces submission report."""
+  """SubmissionReport stores submission info and produces submission report."""
 
-    def __init__(self):
-        self.passed_checks = []
-        self.failed_checks = []
-        self.errors = []
-        self.results = {}
+  def __init__(self):
+    self.passed_checks = []
+    self.failed_checks = []
+    self.errors = []
+    self.results = {}
 
-    def add_passed_check(self, msg):
-        self.passed_checks.append(msg)
+  def add_passed_check(self, msg):
+    self.passed_checks.append(msg)
 
-    def add_failed_check(self, msg):
-        self.failed_checks.append(msg)
-    
-    def add_error(self, msg):
-        self.errors.append(msg)
+  def add_failed_check(self, msg):
+    self.failed_checks.append(msg)
 
-    def set_results(self, results):
-        self.results = results
+  def add_error(self, msg):
+    self.errors.append(msg)
 
-    def print_report(self, verbose=True):
+  def set_results(self, results):
+    self.results = results
 
-        # print summary
-        print("\n" +
-              "MLPERF SUBMISSION REPORT\n" +
-              "========================\n")
-        print("\n" +
-              "SUMMARY\n" +
-              "-------\n")
-        print("Passed checks: {}\n".format(len(self.passed_checks)) +
-              "Failed checks: {}\n".format(len(self.failed_checks)) +
-              "Errors: {}".format(len(self.errors)))
-        print("Note: the Errors indicate certain checks being skipped or " +
-              "early terminated due to errors. The errors are likely caused " +
-              "by failed checks above.")
+  def print_report(self, verbose=True):
 
-        # print succeeded checks (in verbose mode only)
-        if verbose:
-            print("\n" +
-                  "PASSED CHECKS\n" +
-                  "-------------\n")
-            for msg in self.passed_checks:
-                print(msg)
+    # print summary
+    print("\n" + "MLPERF SUBMISSION REPORT\n" + "========================\n")
+    print("\n" + "SUMMARY\n" + "-------\n")
+    print("Passed checks: {}\n".format(len(self.passed_checks)) +
+          "Failed checks: {}\n".format(len(self.failed_checks)) +
+          "Errors: {}".format(len(self.errors)))
+    print("Note: the Errors indicate certain checks being skipped or " +
+          "early terminated due to errors. The errors are likely caused " +
+          "by failed checks above.")
 
-        # print failed checks
-        print("\n" +
-                "FAILED CHECKS\n" +
-                "-------------\n")
-        for msg in self.failed_checks:
-            print(msg)
+    # print succeeded checks (in verbose mode only)
+    if verbose:
+      print("\n" + "PASSED CHECKS\n" + "-------------\n")
+      for msg in self.passed_checks:
+        print(msg)
 
-        # print errors
-        print("\n" +
-                "ERRORS\n" +
-                "------\n")
-        for msg in self.errors:
-            print(msg)
+    # print failed checks
+    print("\n" + "FAILED CHECKS\n" + "-------------\n")
+    for msg in self.failed_checks:
+      print(msg)
 
-    def print_results(self):
-        result_columns = RESULT_SUBM_META_COLUMNS + RESULT_ENTRY_META_COLUMNS + BENCHMARK_NAMES
+    # print errors
+    print("\n" + "ERRORS\n" + "------\n")
+    for msg in self.errors:
+      print(msg)
 
-        print("\n" +
-              "RESULTS\n" +
-              "-------\n")
-        print(",".join(result_columns))
-        for entry_name in self.results:
-            value_list = [self.results[entry_name][key] for key in result_columns]
-            value_list = ["-" if val is None else str(val) for val in value_list]
-            print(",".join(value_list))
+  def print_results(self):
+    result_columns = RESULT_SUBM_META_COLUMNS + RESULT_ENTRY_META_COLUMNS + BENCHMARK_NAMES
+
+    print("\n" + "RESULTS\n" + "-------\n")
+    print(",".join(result_columns))
+    for entry_name in self.results:
+      value_list = [self.results[entry_name][key] for key in result_columns]
+      value_list = ["-" if val is None else str(val) for val in value_list]
+      print(",".join(value_list))

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_0.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_0.txt
@@ -1,0 +1,157 @@
+:::MLPv0.5.0 ncf 1541629769.806975603 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541629798.384909630 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541629798.385934353 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541629827.547986507 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541629829.221915245 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541629829.383048534 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541629829.384613514 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541629829.548022985 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541629829.549335003 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541629829.550442696 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541629829.551510334 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541629829.552565098 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541629829.553709745 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541629830.350249052 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541629830.351327419 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541629830.352361441 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541629834.980409622 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541629834.981530905 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541629841.341938496 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541629852.995471954 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541629853.265025616 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541629853.266101837 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541629853.267829657 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541629854.362714529 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541629870.623628139 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541629874.486646891 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541629892.773094177 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541629892.774147749 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541629892.774910212 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541629902.770447969 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 0}
+:::MLPv0.5.0 ncf 1541629902.771357059 (ncf_main.py:298) eval_accuracy : {"value": 0.5306549668312073, "epoch": 0}
+:::MLPv0.5.0 ncf 1541629902.772117376 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 0}
+:::MLPv0.5.0 ncf 1541629902.772958279 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541629902.773762226 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541629902.775378704 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541629904.237593412 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541629916.553935766 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541629916.800046206 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541629916.800958633 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541629916.803359985 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541629917.970843792 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541629917.972341061 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541629917.973589420 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541629928.851382732 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541629929.291999578 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541629937.832764149 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 1}
+:::MLPv0.5.0 ncf 1541629937.834012508 (ncf_main.py:298) eval_accuracy : {"value": 0.592715859413147, "epoch": 1}
+:::MLPv0.5.0 ncf 1541629937.835010290 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 1}
+:::MLPv0.5.0 ncf 1541629937.836045980 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541629937.837090492 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541629937.838867664 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541629942.990456820 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541629943.248872757 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541629943.249788523 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541629943.251494646 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541629944.328391790 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541629944.329252005 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541629944.330059528 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541629955.852084875 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541629955.932825804 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541629965.015548706 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 2}
+:::MLPv0.5.0 ncf 1541629965.016636848 (ncf_main.py:298) eval_accuracy : {"value": 0.613258421421051, "epoch": 2}
+:::MLPv0.5.0 ncf 1541629965.017606497 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 2}
+:::MLPv0.5.0 ncf 1541629965.018580198 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541629965.019594193 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541629965.021448135 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541629969.613793850 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541629969.866879225 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541629969.867902756 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541629969.869666576 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541629970.971221685 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541629970.972265720 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541629970.973039150 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541629982.223987341 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541629982.718806505 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541629991.377379656 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 3}
+:::MLPv0.5.0 ncf 1541629991.379064083 (ncf_main.py:298) eval_accuracy : {"value": 0.6254900693893433, "epoch": 3}
+:::MLPv0.5.0 ncf 1541629991.380533695 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 3}
+:::MLPv0.5.0 ncf 1541629991.382159472 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541629991.383623600 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541629991.387483835 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541629996.918225288 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541629997.195878267 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541629997.196891069 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541629997.198756456 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541629998.366734028 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541629998.367702007 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541629998.368456125 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541630009.790888309 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541630010.342236757 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541630018.726572275 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 4}
+:::MLPv0.5.0 ncf 1541630018.727678537 (ncf_main.py:298) eval_accuracy : {"value": 0.6303712129592896, "epoch": 4}
+:::MLPv0.5.0 ncf 1541630018.728816271 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 4}
+:::MLPv0.5.0 ncf 1541630018.729892015 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541630018.730926037 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541630018.732652426 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541630024.131653070 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541630024.387812853 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541630024.388681412 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541630024.390431404 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541630025.477633238 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541630025.478599548 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541630025.479360104 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541630036.903758764 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541630037.281498194 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541630046.062421560 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 5}
+:::MLPv0.5.0 ncf 1541630046.063915491 (ncf_main.py:298) eval_accuracy : {"value": 0.631526529788971, "epoch": 5}
+:::MLPv0.5.0 ncf 1541630046.065145016 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 5}
+:::MLPv0.5.0 ncf 1541630046.066528320 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541630046.067807674 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541630046.070402861 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541630051.634691477 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541630051.901442051 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541630051.902601957 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541630051.904453516 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541630053.098103285 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541630053.099166870 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541630053.100075006 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541630064.520211697 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541630065.385507107 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541630073.588383913 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 6}
+:::MLPv0.5.0 ncf 1541630073.589530706 (ncf_main.py:298) eval_accuracy : {"value": 0.6349851489067078, "epoch": 6}
+:::MLPv0.5.0 ncf 1541630073.590510607 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 6}
+:::MLPv0.5.0 ncf 1541630073.591584444 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541630073.592599154 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541630073.594210386 (ncf_main.py:250) train_epoch : 7
+:::MLPv0.5.0 ncf 1541630079.577353716 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541630079.842511654 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541630079.843434334 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541630079.845217705 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541630080.996715307 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541630080.997721434 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541630080.998418093 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541630092.849597931 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541630093.108148336 (ncf_main.py:288) eval_start : 7
+:::MLPv0.5.0 ncf 1541630102.393460751 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 7}
+:::MLPv0.5.0 ncf 1541630102.394617081 (ncf_main.py:298) eval_accuracy : {"value": 0.6316348314285278, "epoch": 7}
+:::MLPv0.5.0 ncf 1541630102.395697832 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 7}
+:::MLPv0.5.0 ncf 1541630102.396800518 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541630102.397821426 (ncf_main.py:307) eval_stop : 7
+:::MLPv0.5.0 ncf 1541630102.399500370 (ncf_main.py:250) train_epoch : 8
+:::MLPv0.5.0 ncf 1541630106.695773363 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541630106.956234217 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541630106.957199335 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541630106.958822250 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541630108.131520271 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541630108.132481813 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541630108.133234024 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541630119.643209457 (ncf_main.py:288) eval_start : 8
+:::MLPv0.5.0 ncf 1541630120.149136782 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541630128.738948345 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 8}
+:::MLPv0.5.0 ncf 1541630128.740088463 (ncf_main.py:298) eval_accuracy : {"value": 0.6369997262954712, "epoch": 8}
+:::MLPv0.5.0 ncf 1541630128.741153717 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 8}
+:::MLPv0.5.0 ncf 1541630128.742220640 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541630128.743262768 (ncf_main.py:307) eval_stop : 8
+:::MLPv0.5.0 ncf 1541630128.745056629 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541630133.904508591 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_1.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_1.txt
@@ -1,0 +1,142 @@
+:::MLPv0.5.0 ncf 1541638895.031234026 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541638923.236273527 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541638923.237526655 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541638952.327059031 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541638953.899754524 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541638954.070998192 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541638954.072480679 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541638954.227394104 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541638954.228630543 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541638954.229835272 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541638954.230996609 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541638954.232165098 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541638954.233321428 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541638955.027998924 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638955.028861761 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638955.029631615 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638958.984930515 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541638958.986066341 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541638963.482089281 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638972.804437160 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638973.017053843 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638973.017826796 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638973.019382238 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638973.917438269 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541638989.355852604 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541638993.658016682 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541639011.406038761 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639011.406930923 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639011.407557964 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639020.111869097 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639021.467950821 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 0}
+:::MLPv0.5.0 ncf 1541639021.469745398 (ncf_main.py:298) eval_accuracy : {"value": 0.5373484492301941, "epoch": 0}
+:::MLPv0.5.0 ncf 1541639021.471030474 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 0}
+:::MLPv0.5.0 ncf 1541639021.472223282 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639021.473330021 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541639021.475375891 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541639032.515873671 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639032.743662119 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639032.744587421 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639032.746376038 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639033.716607571 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639033.717540264 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639033.718369246 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639042.926178694 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639045.802759647 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541639054.909656763 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 1}
+:::MLPv0.5.0 ncf 1541639054.910654068 (ncf_main.py:298) eval_accuracy : {"value": 0.5931130051612854, "epoch": 1}
+:::MLPv0.5.0 ncf 1541639054.911531687 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 1}
+:::MLPv0.5.0 ncf 1541639054.912374496 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639054.913208246 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541639054.916062355 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541639057.041380882 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639057.275251865 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639057.276146173 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639057.277952194 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639058.295663357 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639058.296445847 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639058.297232866 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639067.436517954 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639070.333390951 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541639079.332252979 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 2}
+:::MLPv0.5.0 ncf 1541639079.333365440 (ncf_main.py:298) eval_accuracy : {"value": 0.6087672114372253, "epoch": 2}
+:::MLPv0.5.0 ncf 1541639079.334429979 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 2}
+:::MLPv0.5.0 ncf 1541639079.335534573 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639079.336544275 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541639079.338335037 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541639081.162839174 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639081.385721207 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639081.386645555 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639081.388340235 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639082.345177174 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639082.346069336 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639082.346751928 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639091.358014584 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639093.657176971 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541639102.590484858 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 3}
+:::MLPv0.5.0 ncf 1541639102.591530800 (ncf_main.py:298) eval_accuracy : {"value": 0.6220602989196777, "epoch": 3}
+:::MLPv0.5.0 ncf 1541639102.592370749 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 3}
+:::MLPv0.5.0 ncf 1541639102.593195677 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639102.594020605 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541639102.595510721 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541639104.920227289 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639105.141540527 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639105.142385721 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639105.144113541 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639106.082429647 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639106.083290815 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639106.084046125 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639114.932725191 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639117.956361771 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541639127.011013269 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 4}
+:::MLPv0.5.0 ncf 1541639127.012416601 (ncf_main.py:298) eval_accuracy : {"value": 0.6337793469429016, "epoch": 4}
+:::MLPv0.5.0 ncf 1541639127.013852596 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 4}
+:::MLPv0.5.0 ncf 1541639127.015208721 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639127.016513586 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541639127.018818855 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541639128.249584675 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639128.469122171 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639128.469949484 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639128.471689939 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639129.393888474 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639129.394659042 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639129.395437241 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639138.089647770 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639141.253282070 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541639150.173605204 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 5}
+:::MLPv0.5.0 ncf 1541639150.175257921 (ncf_main.py:298) eval_accuracy : {"value": 0.6301618218421936, "epoch": 5}
+:::MLPv0.5.0 ncf 1541639150.176603079 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 5}
+:::MLPv0.5.0 ncf 1541639150.178146601 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639150.179577351 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541639150.182994366 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541639151.672637224 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639151.891428947 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639151.892314196 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639151.894017458 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639152.842330933 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639152.843183756 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639152.844506264 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639161.799849510 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639164.521182537 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541639173.483475447 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 6}
+:::MLPv0.5.0 ncf 1541639173.484593630 (ncf_main.py:298) eval_accuracy : {"value": 0.6319236159324646, "epoch": 6}
+:::MLPv0.5.0 ncf 1541639173.485693693 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 6}
+:::MLPv0.5.0 ncf 1541639173.486776829 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639173.487823009 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541639173.489987850 (ncf_main.py:250) train_epoch : 7
+:::MLPv0.5.0 ncf 1541639175.265949488 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639175.495955944 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639175.496826887 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639175.498592615 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639176.444577217 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639176.445418835 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639176.446123600 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639185.473111629 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639187.726145983 (ncf_main.py:288) eval_start : 7
+:::MLPv0.5.0 ncf 1541639196.610095263 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 7}
+:::MLPv0.5.0 ncf 1541639196.611189604 (ncf_main.py:298) eval_accuracy : {"value": 0.6351801156997681, "epoch": 7}
+:::MLPv0.5.0 ncf 1541639196.612210035 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 7}
+:::MLPv0.5.0 ncf 1541639196.613304853 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639196.614780188 (ncf_main.py:307) eval_stop : 7
+:::MLPv0.5.0 ncf 1541639196.618208647 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541639202.765043259 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_2.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_2.txt
@@ -1,0 +1,127 @@
+:::MLPv0.5.0 ncf 1541635592.735490084 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541635621.643852949 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541635621.644915342 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541635650.525794268 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541635651.950720072 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541635652.146502495 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541635652.147968292 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541635652.294246912 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541635652.295337915 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541635652.296380043 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541635652.297379255 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541635652.298405170 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541635652.299393654 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541635653.289041758 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635653.290127754 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635653.291014433 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635656.965124607 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541635656.966187954 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541635661.936030626 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635670.668617964 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635670.874290466 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635670.875072479 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635670.876661062 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635671.744560242 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541635686.960785389 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541635690.082700014 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541635707.011981010 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635707.012933254 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635707.013725281 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635715.568417549 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635716.953304768 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 0}
+:::MLPv0.5.0 ncf 1541635716.955264330 (ncf_main.py:298) eval_accuracy : {"value": 0.5354422330856323, "epoch": 0}
+:::MLPv0.5.0 ncf 1541635716.956701756 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 0}
+:::MLPv0.5.0 ncf 1541635716.958046198 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635716.959423304 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541635716.962947369 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541635726.944634438 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635727.147002935 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635727.147855759 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635727.149498940 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635728.041645765 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635728.042531729 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635728.043314695 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635736.657572508 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635739.158473492 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541635748.078444958 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 1}
+:::MLPv0.5.0 ncf 1541635748.079842806 (ncf_main.py:298) eval_accuracy : {"value": 0.5965427756309509, "epoch": 1}
+:::MLPv0.5.0 ncf 1541635748.081184626 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 1}
+:::MLPv0.5.0 ncf 1541635748.082456589 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635748.083766937 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541635748.087042809 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541635749.299320221 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635749.496930838 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635749.497620583 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635749.499307632 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635750.400596380 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635750.401340723 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635750.402051210 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635759.082277775 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635762.224506140 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541635771.070236206 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 2}
+:::MLPv0.5.0 ncf 1541635771.071095705 (ncf_main.py:298) eval_accuracy : {"value": 0.6109262108802795, "epoch": 2}
+:::MLPv0.5.0 ncf 1541635771.071941614 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 2}
+:::MLPv0.5.0 ncf 1541635771.072973728 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635771.073931217 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541635771.075494289 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541635771.735477686 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635771.934694290 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635771.935521603 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635771.937023878 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635772.842210293 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635772.842930555 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635772.844555855 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635781.700635433 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635784.204189301 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541635793.030010939 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 3}
+:::MLPv0.5.0 ncf 1541635793.031024933 (ncf_main.py:298) eval_accuracy : {"value": 0.6213093996047974, "epoch": 3}
+:::MLPv0.5.0 ncf 1541635793.031959772 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 3}
+:::MLPv0.5.0 ncf 1541635793.032881021 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635793.033894062 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541635793.035282850 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541635794.247166157 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635794.443239450 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635794.444090366 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635794.446002722 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635795.325319529 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635795.326089144 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635795.326739788 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635803.975391626 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635807.174386263 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541635816.100397587 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 4}
+:::MLPv0.5.0 ncf 1541635816.101409197 (ncf_main.py:298) eval_accuracy : {"value": 0.628631055355072, "epoch": 4}
+:::MLPv0.5.0 ncf 1541635816.102323532 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 4}
+:::MLPv0.5.0 ncf 1541635816.103255987 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635816.104213476 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541635816.105989695 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541635817.220807791 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635817.420272112 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635817.421089411 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635817.422892332 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635818.317587852 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635818.318344355 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635818.318983078 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635827.135539055 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635830.379570484 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541635839.398041487 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 5}
+:::MLPv0.5.0 ncf 1541635839.399200678 (ncf_main.py:298) eval_accuracy : {"value": 0.6302556991577148, "epoch": 5}
+:::MLPv0.5.0 ncf 1541635839.400227547 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 5}
+:::MLPv0.5.0 ncf 1541635839.401436090 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635839.402719975 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541635839.404899597 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541635841.259696484 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635841.458028316 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635841.458848000 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635841.460329533 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635842.350486755 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635842.351144552 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635842.351816177 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635850.800582409 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635853.518856049 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541635862.334436417 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 6}
+:::MLPv0.5.0 ncf 1541635862.335587025 (ncf_main.py:298) eval_accuracy : {"value": 0.6417508721351624, "epoch": 6}
+:::MLPv0.5.0 ncf 1541635862.336535692 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 6}
+:::MLPv0.5.0 ncf 1541635862.337635994 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635862.338615417 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541635862.340265751 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541635867.477297068 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_3.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_3.txt
@@ -1,0 +1,127 @@
+:::MLPv0.5.0 ncf 1541638530.669874907 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541638561.582758665 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541638561.583793640 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541638591.467878819 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541638592.953894854 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541638593.117671490 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541638593.118999958 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541638593.267966270 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541638593.269155025 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541638593.270237923 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541638593.271331310 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541638593.272338390 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541638593.273343563 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541638594.289401293 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638594.290200949 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638594.290861845 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638597.900661469 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541638597.901683331 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541638602.874284029 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638612.318328619 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638612.545264959 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638612.546017408 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638612.547684908 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638613.459522009 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541638629.239745617 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541638633.120075226 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541638650.751036882 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638650.751998901 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638650.752789736 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638660.243846655 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638661.108375072 (ncf_main.py:296) eval_target : {"epoch": 0, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638661.110687017 (ncf_main.py:298) eval_accuracy : {"epoch": 0, "value": 0.5356444120407104}
+:::MLPv0.5.0 ncf 1541638661.112533808 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 0, "value": 999}
+:::MLPv0.5.0 ncf 1541638661.114323378 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638661.116151333 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541638661.120820045 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541638671.748719931 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638671.960242510 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638671.961034775 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638671.962643623 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638672.878739595 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638672.879523277 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638672.880466938 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638682.686112642 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638684.642664671 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541638694.102167130 (ncf_main.py:296) eval_target : {"epoch": 1, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638694.103220463 (ncf_main.py:298) eval_accuracy : {"epoch": 1, "value": 0.58757483959198}
+:::MLPv0.5.0 ncf 1541638694.104175806 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 1, "value": 999}
+:::MLPv0.5.0 ncf 1541638694.105296612 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638694.106267929 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541638694.108056545 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541638696.770808697 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638696.993099689 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638696.994022369 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638696.995660305 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638697.932561159 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638697.933469534 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638697.934192419 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638707.198048353 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638709.624096394 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541638718.868647099 (ncf_main.py:296) eval_target : {"epoch": 2, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638718.869473219 (ncf_main.py:298) eval_accuracy : {"epoch": 2, "value": 0.6153596043586731}
+:::MLPv0.5.0 ncf 1541638718.870290279 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 2, "value": 999}
+:::MLPv0.5.0 ncf 1541638718.871115923 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638718.871890306 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541638718.873318911 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541638720.698725700 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638720.934088707 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638720.934892416 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638720.936585903 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638721.895664454 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638721.896656513 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638721.897491693 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638731.439008951 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638733.294950485 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541638742.417784929 (ncf_main.py:296) eval_target : {"epoch": 3, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638742.418863773 (ncf_main.py:298) eval_accuracy : {"epoch": 3, "value": 0.628912627696991}
+:::MLPv0.5.0 ncf 1541638742.419747114 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 3, "value": 999}
+:::MLPv0.5.0 ncf 1541638742.420757294 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638742.421626806 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541638742.423120737 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541638744.673100710 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638744.884420156 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638744.885207415 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638744.886749744 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638745.789624929 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638745.790396929 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638745.791196823 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638754.539904833 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638757.667276859 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541638766.667538404 (ncf_main.py:296) eval_target : {"epoch": 4, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638766.668629646 (ncf_main.py:298) eval_accuracy : {"epoch": 4, "value": 0.621605396270752}
+:::MLPv0.5.0 ncf 1541638766.669639111 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 4, "value": 999}
+:::MLPv0.5.0 ncf 1541638766.670649767 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638766.671548367 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541638766.673167944 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541638768.128195047 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638768.342603207 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638768.343390465 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638768.345059395 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638769.266900301 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638769.267585278 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638769.268135786 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638778.495992899 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638781.054627657 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541638789.908996582 (ncf_main.py:296) eval_target : {"epoch": 5, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638789.910017729 (ncf_main.py:298) eval_accuracy : {"epoch": 5, "value": 0.6323857307434082}
+:::MLPv0.5.0 ncf 1541638789.910892725 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 5, "value": 999}
+:::MLPv0.5.0 ncf 1541638789.911787748 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638789.912686586 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541638789.914197445 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541638791.479794741 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638791.693878889 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638791.694731474 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638791.696250677 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638792.597578764 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638792.598493814 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638792.599245071 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638801.734756708 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638804.306957722 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541638813.269903660 (ncf_main.py:296) eval_target : {"epoch": 6, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638813.270980597 (ncf_main.py:298) eval_accuracy : {"epoch": 6, "value": 0.6393969655036926}
+:::MLPv0.5.0 ncf 1541638813.271996021 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 6, "value": 999}
+:::MLPv0.5.0 ncf 1541638813.272984028 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638813.273951769 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541638813.275540352 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541638818.417414188 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_4.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_4.txt
@@ -1,0 +1,187 @@
+:::MLPv0.5.0 ncf 1541638735.238862753 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541638763.284983397 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541638763.285973310 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541638792.218703747 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541638793.809119463 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541638793.960701704 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541638793.961995840 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541638794.123754501 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541638794.125000238 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541638794.126100302 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541638794.127219200 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541638794.128327608 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541638794.129439116 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541638795.002657652 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638795.003699064 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638795.004737139 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638799.073868990 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541638799.075083733 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541638804.278205872 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638813.935642004 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638814.165486813 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638814.166306734 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638814.168062687 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638815.102317095 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541638830.649114609 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541638835.380751610 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541638853.196332455 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638853.197302580 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638853.198096514 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638863.102175474 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638863.774731636 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 0}
+:::MLPv0.5.0 ncf 1541638863.776791573 (ncf_main.py:298) eval_accuracy : {"value": 0.5355505347251892, "epoch": 0}
+:::MLPv0.5.0 ncf 1541638863.778720856 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 0}
+:::MLPv0.5.0 ncf 1541638863.780708790 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638863.782530785 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541638863.787337780 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541638875.236955166 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638875.461423874 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638875.462186337 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638875.464098930 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638876.439197302 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638876.440101624 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638876.440862179 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638886.599519014 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638888.022569418 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541638897.121084213 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 1}
+:::MLPv0.5.0 ncf 1541638897.122159481 (ncf_main.py:298) eval_accuracy : {"value": 0.5930985808372498, "epoch": 1}
+:::MLPv0.5.0 ncf 1541638897.123104095 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 1}
+:::MLPv0.5.0 ncf 1541638897.124136209 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638897.125144005 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541638897.126816750 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541638900.439061642 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638900.665209532 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638900.666141033 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638900.667827845 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638901.654235363 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638901.655050516 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638901.655836582 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638911.832676649 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638913.336969376 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541638922.436698914 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 2}
+:::MLPv0.5.0 ncf 1541638922.437777519 (ncf_main.py:298) eval_accuracy : {"value": 0.6151068806648254, "epoch": 2}
+:::MLPv0.5.0 ncf 1541638922.438806534 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 2}
+:::MLPv0.5.0 ncf 1541638922.439902306 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638922.441020012 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541638922.442710400 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541638926.083081245 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638926.307165384 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638926.308060884 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638926.309741020 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638927.284732819 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638927.285611629 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638927.286301136 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638937.344093561 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638938.569292784 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541638947.616512299 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 3}
+:::MLPv0.5.0 ncf 1541638947.617608309 (ncf_main.py:298) eval_accuracy : {"value": 0.6168181896209717, "epoch": 3}
+:::MLPv0.5.0 ncf 1541638947.618635178 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 3}
+:::MLPv0.5.0 ncf 1541638947.619671345 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638947.620631456 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541638947.622097254 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541638951.270486355 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638951.499932289 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638951.500874281 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638951.502548218 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638952.462307453 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638952.463004112 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638952.463751554 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638962.605659246 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638963.907874823 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541638972.984329224 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 4}
+:::MLPv0.5.0 ncf 1541638972.985457182 (ncf_main.py:298) eval_accuracy : {"value": 0.6302845478057861, "epoch": 4}
+:::MLPv0.5.0 ncf 1541638972.986984253 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 4}
+:::MLPv0.5.0 ncf 1541638972.988606453 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638972.989959002 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541638972.992711782 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541638976.508027554 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638976.734097958 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638976.734944820 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638976.736789942 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638977.706576109 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638977.707465649 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638977.708255768 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638987.777219772 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638989.068754673 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541638998.090879202 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 5}
+:::MLPv0.5.0 ncf 1541638998.092196226 (ncf_main.py:298) eval_accuracy : {"value": 0.6349635124206543, "epoch": 5}
+:::MLPv0.5.0 ncf 1541638998.093468666 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 5}
+:::MLPv0.5.0 ncf 1541638998.094665766 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638998.095893860 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541638998.098478794 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541639001.637465715 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639001.867513657 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639001.868403912 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639001.870070696 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639002.827457190 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639002.828288317 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639002.828994989 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639013.103656054 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639014.309495449 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541639023.325899601 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 6}
+:::MLPv0.5.0 ncf 1541639023.327287436 (ncf_main.py:298) eval_accuracy : {"value": 0.6338948607444763, "epoch": 6}
+:::MLPv0.5.0 ncf 1541639023.328736544 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 6}
+:::MLPv0.5.0 ncf 1541639023.330213070 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639023.331642628 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541639023.334031820 (ncf_main.py:250) train_epoch : 7
+:::MLPv0.5.0 ncf 1541639026.669128418 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639026.900388718 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639026.901266575 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639026.903734922 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639027.867920399 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639027.868843079 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639027.869573832 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639038.053215265 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639039.575567961 (ncf_main.py:288) eval_start : 7
+:::MLPv0.5.0 ncf 1541639048.613936663 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 7}
+:::MLPv0.5.0 ncf 1541639048.615044355 (ncf_main.py:298) eval_accuracy : {"value": 0.6348768472671509, "epoch": 7}
+:::MLPv0.5.0 ncf 1541639048.616128683 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 7}
+:::MLPv0.5.0 ncf 1541639048.617212534 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639048.618234873 (ncf_main.py:307) eval_stop : 7
+:::MLPv0.5.0 ncf 1541639048.620325327 (ncf_main.py:250) train_epoch : 8
+:::MLPv0.5.0 ncf 1541639051.946373701 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639052.170110941 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639052.170968771 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639052.172660589 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639053.131777763 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639053.132664204 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639053.133434534 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639063.435886145 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639064.853965521 (ncf_main.py:288) eval_start : 8
+:::MLPv0.5.0 ncf 1541639073.796424389 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 8}
+:::MLPv0.5.0 ncf 1541639073.797993422 (ncf_main.py:298) eval_accuracy : {"value": 0.6314976215362549, "epoch": 8}
+:::MLPv0.5.0 ncf 1541639073.799522161 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 8}
+:::MLPv0.5.0 ncf 1541639073.801043034 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639073.802507401 (ncf_main.py:307) eval_stop : 8
+:::MLPv0.5.0 ncf 1541639073.806848288 (ncf_main.py:250) train_epoch : 9
+:::MLPv0.5.0 ncf 1541639077.021913528 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639077.248788118 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639077.249706030 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639077.251465797 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639078.222069263 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639078.222922325 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639078.223669529 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639088.445314884 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639089.939385414 (ncf_main.py:288) eval_start : 9
+:::MLPv0.5.0 ncf 1541639098.979931116 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 9}
+:::MLPv0.5.0 ncf 1541639098.980998755 (ncf_main.py:298) eval_accuracy : {"value": 0.6349129676818848, "epoch": 9}
+:::MLPv0.5.0 ncf 1541639098.981842041 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 9}
+:::MLPv0.5.0 ncf 1541639098.982664585 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639098.983457565 (ncf_main.py:307) eval_stop : 9
+:::MLPv0.5.0 ncf 1541639098.985089540 (ncf_main.py:250) train_epoch : 10
+:::MLPv0.5.0 ncf 1541639102.237427950 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639102.472718000 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639102.473574400 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639102.475203753 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639103.493594646 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639103.494433880 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639103.495185614 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639113.654072762 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639115.319412231 (ncf_main.py:288) eval_start : 10
+:::MLPv0.5.0 ncf 1541639124.446080923 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 10}
+:::MLPv0.5.0 ncf 1541639124.446999550 (ncf_main.py:298) eval_accuracy : {"value": 0.6357361078262329, "epoch": 10}
+:::MLPv0.5.0 ncf 1541639124.447862625 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 10}
+:::MLPv0.5.0 ncf 1541639124.449436665 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639124.450917006 (ncf_main.py:307) eval_stop : 10
+:::MLPv0.5.0 ncf 1541639124.454472303 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541639129.607702017 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_5.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_5.txt
@@ -1,0 +1,157 @@
+:::MLPv0.5.0 ncf 1541638763.440427065 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541638790.779615164 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541638790.780507803 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541638819.940380812 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541638821.379003525 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541638821.534843683 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541638821.536063910 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541638821.679996252 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541638821.681133509 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541638821.682166576 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541638821.683179617 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541638821.684192419 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541638821.685162306 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541638822.613849878 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638822.614837170 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638822.615612984 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638826.204838276 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541638826.205809355 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541638831.776727200 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638841.261714458 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638841.475725651 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638841.476668119 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638841.478289366 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638842.397707701 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541638858.403058529 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541638861.475663424 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541638878.624043465 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638878.624924421 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638878.625625849 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638888.412789345 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638888.917968035 (ncf_main.py:296) eval_target : {"epoch": 0, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638888.920070887 (ncf_main.py:298) eval_accuracy : {"epoch": 0, "value": 0.5279328227043152}
+:::MLPv0.5.0 ncf 1541638888.921729088 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 0, "value": 999}
+:::MLPv0.5.0 ncf 1541638888.923309326 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638888.924749374 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541638888.929114819 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541638900.195536137 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638900.399672270 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638900.400523186 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638900.402125120 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638901.344372511 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638901.345240355 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638901.345992088 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638911.365325689 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638913.131508350 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541638922.109789371 (ncf_main.py:296) eval_target : {"epoch": 1, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638922.110926628 (ncf_main.py:298) eval_accuracy : {"epoch": 1, "value": 0.5782313942909241}
+:::MLPv0.5.0 ncf 1541638922.111940145 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 1, "value": 999}
+:::MLPv0.5.0 ncf 1541638922.112982035 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638922.113954067 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541638922.115504980 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541638924.538333178 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638924.745608091 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638924.746380806 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638924.749269247 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638925.686165333 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638925.686889172 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638925.687494993 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638935.590030909 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638937.294821262 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541638946.289694071 (ncf_main.py:296) eval_target : {"epoch": 2, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638946.290822268 (ncf_main.py:298) eval_accuracy : {"epoch": 2, "value": 0.6097131371498108}
+:::MLPv0.5.0 ncf 1541638946.291926384 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 2, "value": 999}
+:::MLPv0.5.0 ncf 1541638946.293175459 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638946.294192553 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541638946.296341181 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541638948.400600910 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638948.611230612 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638948.612046242 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638948.613714218 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638949.553132296 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638949.553850174 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638949.554521561 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638959.460954189 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638961.404874086 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541638970.316626787 (ncf_main.py:296) eval_target : {"epoch": 3, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638970.318053722 (ncf_main.py:298) eval_accuracy : {"epoch": 3, "value": 0.6186810731887817}
+:::MLPv0.5.0 ncf 1541638970.319359541 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 3, "value": 999}
+:::MLPv0.5.0 ncf 1541638970.320714712 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638970.322079659 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541638970.325397015 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541638972.837314129 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638973.050715685 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638973.051517487 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638973.053102970 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638974.001861095 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638974.002641201 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638974.003303289 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638983.682631969 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638985.509771109 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541638994.446334600 (ncf_main.py:296) eval_target : {"epoch": 4, "value": 0.635}
+:::MLPv0.5.0 ncf 1541638994.447399855 (ncf_main.py:298) eval_accuracy : {"epoch": 4, "value": 0.6311221718788147}
+:::MLPv0.5.0 ncf 1541638994.448939085 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 4, "value": 999}
+:::MLPv0.5.0 ncf 1541638994.450215578 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638994.451440334 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541638994.454709053 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541638996.432271004 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638996.635140657 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638996.635883808 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638996.637431145 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638997.594397783 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638997.595444202 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638997.596254110 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639007.279758215 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639008.539303541 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541639017.558956861 (ncf_main.py:296) eval_target : {"epoch": 5, "value": 0.635}
+:::MLPv0.5.0 ncf 1541639017.560356617 (ncf_main.py:298) eval_accuracy : {"epoch": 5, "value": 0.6311654448509216}
+:::MLPv0.5.0 ncf 1541639017.561654568 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 5, "value": 999}
+:::MLPv0.5.0 ncf 1541639017.562897205 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639017.564193726 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541639017.567703962 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541639020.146848440 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639020.354084730 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639020.354932070 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639020.356535912 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639021.275757551 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639021.276599407 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639021.277253628 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639031.074332237 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639032.801159382 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541639041.756096125 (ncf_main.py:296) eval_target : {"epoch": 6, "value": 0.635}
+:::MLPv0.5.0 ncf 1541639041.756878853 (ncf_main.py:298) eval_accuracy : {"epoch": 6, "value": 0.6286599040031433}
+:::MLPv0.5.0 ncf 1541639041.757618189 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 6, "value": 999}
+:::MLPv0.5.0 ncf 1541639041.758368731 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639041.759097338 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541639041.760601759 (ncf_main.py:250) train_epoch : 7
+:::MLPv0.5.0 ncf 1541639043.498859882 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639043.696454525 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639043.697260141 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639043.698834181 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639044.589266777 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639044.590030670 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639044.590780020 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639054.153103590 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639055.968831062 (ncf_main.py:288) eval_start : 7
+:::MLPv0.5.0 ncf 1541639064.915617704 (ncf_main.py:296) eval_target : {"epoch": 7, "value": 0.635}
+:::MLPv0.5.0 ncf 1541639064.916630030 (ncf_main.py:298) eval_accuracy : {"epoch": 7, "value": 0.6326096057891846}
+:::MLPv0.5.0 ncf 1541639064.917640924 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 7, "value": 999}
+:::MLPv0.5.0 ncf 1541639064.918621540 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639064.919554234 (ncf_main.py:307) eval_stop : 7
+:::MLPv0.5.0 ncf 1541639064.921204090 (ncf_main.py:250) train_epoch : 8
+:::MLPv0.5.0 ncf 1541639067.292711258 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639067.498054266 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639067.498902559 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639067.500632524 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639068.435379267 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639068.436191559 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639068.436933756 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639078.104113579 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639080.104954004 (ncf_main.py:288) eval_start : 8
+:::MLPv0.5.0 ncf 1541639089.076507092 (ncf_main.py:296) eval_target : {"epoch": 8, "value": 0.635}
+:::MLPv0.5.0 ncf 1541639089.077627182 (ncf_main.py:298) eval_accuracy : {"epoch": 8, "value": 0.6405161023139954}
+:::MLPv0.5.0 ncf 1541639089.078667402 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 8, "value": 999}
+:::MLPv0.5.0 ncf 1541639089.079668045 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639089.080657959 (ncf_main.py:307) eval_stop : 8
+:::MLPv0.5.0 ncf 1541639089.082299232 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541639095.228493929 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_6.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_6.txt
@@ -1,0 +1,112 @@
+:::MLPv0.5.0 ncf 1541635104.310555458 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541635131.471904993 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541635131.472935915 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541635159.243577003 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541635160.774804592 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541635160.940083504 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541635160.941361666 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541635161.090290546 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541635161.091511726 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541635161.092599154 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541635161.093669176 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541635161.094815493 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541635161.095993996 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541635162.026654720 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635162.027592182 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635162.028356314 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635165.954928398 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541635165.956025600 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541635171.832559586 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635182.169102907 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635182.401242733 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635182.402066946 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635182.403608084 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635183.356632233 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541635199.252304316 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541635202.663941860 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541635220.301067829 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635220.302071810 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635220.303174496 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635230.153288841 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 0}
+:::MLPv0.5.0 ncf 1541635230.154069424 (ncf_main.py:298) eval_accuracy : {"value": 0.5405616164207458, "epoch": 0}
+:::MLPv0.5.0 ncf 1541635230.154792309 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 0}
+:::MLPv0.5.0 ncf 1541635230.155698061 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635230.156645060 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541635230.158128262 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541635230.840999365 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635242.693369865 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635242.926271439 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635242.927160025 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635242.928939104 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635243.977257490 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635243.977997303 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635243.978714228 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635254.760675192 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635255.229307890 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541635264.206905127 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 1}
+:::MLPv0.5.0 ncf 1541635264.208005667 (ncf_main.py:298) eval_accuracy : {"value": 0.5901886820793152, "epoch": 1}
+:::MLPv0.5.0 ncf 1541635264.208961487 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 1}
+:::MLPv0.5.0 ncf 1541635264.209945202 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635264.210886955 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541635264.212466002 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541635268.100805759 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635268.339647532 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635268.340467215 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635268.341966867 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635269.361189842 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635269.362025023 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635269.362709761 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635279.805070877 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635281.209762573 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541635290.199726343 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 2}
+:::MLPv0.5.0 ncf 1541635290.200830936 (ncf_main.py:298) eval_accuracy : {"value": 0.6160889267921448, "epoch": 2}
+:::MLPv0.5.0 ncf 1541635290.201836824 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 2}
+:::MLPv0.5.0 ncf 1541635290.202774525 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635290.203707695 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541635290.205309153 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541635293.114334106 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635293.349895716 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635293.350741863 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635293.352239847 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635294.374027967 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635294.374819994 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635294.375455618 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635305.165984392 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635306.245191574 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541635315.263355970 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 3}
+:::MLPv0.5.0 ncf 1541635315.264427185 (ncf_main.py:298) eval_accuracy : {"value": 0.6182406544685364, "epoch": 3}
+:::MLPv0.5.0 ncf 1541635315.265385866 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 3}
+:::MLPv0.5.0 ncf 1541635315.266289711 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635315.267217875 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541635315.271013260 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541635318.532382250 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635318.769673824 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635318.770560503 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635318.772199631 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635319.784989834 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635319.785841465 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635319.786663532 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635330.223200560 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635331.300731897 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541635340.334658146 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 4}
+:::MLPv0.5.0 ncf 1541635340.335757256 (ncf_main.py:298) eval_accuracy : {"value": 0.6218942403793335, "epoch": 4}
+:::MLPv0.5.0 ncf 1541635340.337112665 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 4}
+:::MLPv0.5.0 ncf 1541635340.338456869 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635340.339895725 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541635340.343821287 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541635343.544234753 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541635343.779250383 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541635343.780206680 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541635343.781805277 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541635344.787969351 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541635344.788851500 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541635344.789602280 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541635355.629423380 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541635356.461983919 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541635365.410529137 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 5}
+:::MLPv0.5.0 ncf 1541635365.411608458 (ncf_main.py:298) eval_accuracy : {"value": 0.6367903351783752, "epoch": 5}
+:::MLPv0.5.0 ncf 1541635365.412614107 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 5}
+:::MLPv0.5.0 ncf 1541635365.413582802 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541635365.414509773 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541635365.416010141 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541635371.566162825 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_7.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_7.txt
@@ -1,0 +1,232 @@
+:::MLPv0.5.0 ncf 1541638648.550307274 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541638677.071330070 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541638677.072561979 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541638705.039521694 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541638706.670266390 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541638706.826765537 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541638706.828184128 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541638706.985775471 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541638706.987082481 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541638706.988264561 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541638706.989395857 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541638706.990535021 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541638706.991703749 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541638707.827156305 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638707.828113556 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638707.828854799 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638711.912560463 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541638711.913695574 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541638717.573549032 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638727.377744675 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638727.607499361 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638727.608463526 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638727.610274553 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638728.564833403 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541638744.498449087 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541638749.060900688 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541638768.275154829 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638768.276139736 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638768.276959896 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638777.796409845 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638778.578298330 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 0}
+:::MLPv0.5.0 ncf 1541638778.579566717 (ncf_main.py:298) eval_accuracy : {"value": 0.5355721712112427, "epoch": 0}
+:::MLPv0.5.0 ncf 1541638778.580665112 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 0}
+:::MLPv0.5.0 ncf 1541638778.581835747 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638778.582897902 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541638778.585196495 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541638789.774667978 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638790.003770113 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638790.004733562 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638790.006499290 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638791.009516478 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638791.010442019 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638791.011214495 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638800.901390076 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638802.952246904 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541638812.051494837 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 1}
+:::MLPv0.5.0 ncf 1541638812.052587509 (ncf_main.py:298) eval_accuracy : {"value": 0.5825492739677429, "epoch": 1}
+:::MLPv0.5.0 ncf 1541638812.054286957 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 1}
+:::MLPv0.5.0 ncf 1541638812.056334496 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638812.058329582 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541638812.063334703 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541638815.112897158 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638815.351840734 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638815.352747679 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638815.354386568 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638816.401205540 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638816.402038574 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638816.402697563 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638826.358629942 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638828.482375145 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541638837.589383125 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 2}
+:::MLPv0.5.0 ncf 1541638837.590895414 (ncf_main.py:298) eval_accuracy : {"value": 0.6043915748596191, "epoch": 2}
+:::MLPv0.5.0 ncf 1541638837.592641830 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 2}
+:::MLPv0.5.0 ncf 1541638837.594459057 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638837.596236944 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541638837.600217104 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541638840.670164347 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638840.901393890 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638840.902322769 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638840.904255867 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638841.919704437 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638841.920623541 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638841.921340466 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638851.890675306 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638853.890926838 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541638863.027609110 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 3}
+:::MLPv0.5.0 ncf 1541638863.028797626 (ncf_main.py:298) eval_accuracy : {"value": 0.6211938261985779, "epoch": 3}
+:::MLPv0.5.0 ncf 1541638863.029858112 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 3}
+:::MLPv0.5.0 ncf 1541638863.030918360 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638863.032007933 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541638863.035703182 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541638865.837581158 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638866.066373348 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638866.067242622 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638866.068979740 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638867.089495420 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638867.090789557 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638867.091881752 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638876.884055376 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638878.318868637 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541638887.453387022 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 4}
+:::MLPv0.5.0 ncf 1541638887.454644918 (ncf_main.py:298) eval_accuracy : {"value": 0.6266164779663086, "epoch": 4}
+:::MLPv0.5.0 ncf 1541638887.455842257 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 4}
+:::MLPv0.5.0 ncf 1541638887.457065105 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638887.458268166 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541638887.460571527 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541638891.187935352 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638891.417843580 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638891.418778896 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638891.420610905 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638892.425272942 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638892.426149368 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638892.426887274 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638902.111029863 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638903.784252882 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541638913.010018349 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 5}
+:::MLPv0.5.0 ncf 1541638913.011149883 (ncf_main.py:298) eval_accuracy : {"value": 0.626602053642273, "epoch": 5}
+:::MLPv0.5.0 ncf 1541638913.012211800 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 5}
+:::MLPv0.5.0 ncf 1541638913.013282776 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638913.014289141 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541638913.015935421 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541638916.771363020 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638917.004644871 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638917.005646229 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638917.008382082 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638918.012643337 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638918.013614655 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638918.014599323 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638927.594116926 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638929.446775675 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541638938.570993185 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 6}
+:::MLPv0.5.0 ncf 1541638938.572448015 (ncf_main.py:298) eval_accuracy : {"value": 0.6349635124206543, "epoch": 6}
+:::MLPv0.5.0 ncf 1541638938.573783398 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 6}
+:::MLPv0.5.0 ncf 1541638938.575094700 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638938.576342583 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541638938.578654766 (ncf_main.py:250) train_epoch : 7
+:::MLPv0.5.0 ncf 1541638941.692667484 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638941.922924995 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638941.923849344 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638941.925620794 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638942.935578108 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638942.936476469 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638942.937253952 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638952.531521082 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638954.897549868 (ncf_main.py:288) eval_start : 7
+:::MLPv0.5.0 ncf 1541638964.103841782 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 7}
+:::MLPv0.5.0 ncf 1541638964.105089188 (ncf_main.py:298) eval_accuracy : {"value": 0.6335626840591431, "epoch": 7}
+:::MLPv0.5.0 ncf 1541638964.106173038 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 7}
+:::MLPv0.5.0 ncf 1541638964.107293367 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638964.108463049 (ncf_main.py:307) eval_stop : 7
+:::MLPv0.5.0 ncf 1541638964.110485792 (ncf_main.py:250) train_epoch : 8
+:::MLPv0.5.0 ncf 1541638966.973208904 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638967.203658581 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638967.204607010 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638967.206352234 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638968.233442068 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638968.234580517 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638968.235488653 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541638978.180021524 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541638979.381479025 (ncf_main.py:288) eval_start : 8
+:::MLPv0.5.0 ncf 1541638988.413835287 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 8}
+:::MLPv0.5.0 ncf 1541638988.415410757 (ncf_main.py:298) eval_accuracy : {"value": 0.6319958567619324, "epoch": 8}
+:::MLPv0.5.0 ncf 1541638988.416940689 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 8}
+:::MLPv0.5.0 ncf 1541638988.418448210 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541638988.419909000 (ncf_main.py:307) eval_stop : 8
+:::MLPv0.5.0 ncf 1541638988.423610687 (ncf_main.py:250) train_epoch : 9
+:::MLPv0.5.0 ncf 1541638992.395078421 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541638992.628517866 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541638992.629472017 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541638992.631278753 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541638993.648834944 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541638993.649730921 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541638993.650494337 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639003.502723694 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639005.726691961 (ncf_main.py:288) eval_start : 9
+:::MLPv0.5.0 ncf 1541639014.860283136 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 9}
+:::MLPv0.5.0 ncf 1541639014.861481667 (ncf_main.py:298) eval_accuracy : {"value": 0.6324362754821777, "epoch": 9}
+:::MLPv0.5.0 ncf 1541639014.862538099 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 9}
+:::MLPv0.5.0 ncf 1541639014.863608122 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639014.864690304 (ncf_main.py:307) eval_stop : 9
+:::MLPv0.5.0 ncf 1541639014.866374016 (ncf_main.py:250) train_epoch : 10
+:::MLPv0.5.0 ncf 1541639017.435810089 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639017.667629004 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639017.668562889 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639017.670313597 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639018.692301035 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639018.693156958 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639018.693868399 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639028.311717987 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639030.179833651 (ncf_main.py:288) eval_start : 10
+:::MLPv0.5.0 ncf 1541639039.233758688 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 10}
+:::MLPv0.5.0 ncf 1541639039.234900475 (ncf_main.py:298) eval_accuracy : {"value": 0.631252110004425, "epoch": 10}
+:::MLPv0.5.0 ncf 1541639039.236017466 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 10}
+:::MLPv0.5.0 ncf 1541639039.237156153 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639039.238312483 (ncf_main.py:307) eval_stop : 10
+:::MLPv0.5.0 ncf 1541639039.239964247 (ncf_main.py:250) train_epoch : 11
+:::MLPv0.5.0 ncf 1541639042.740925789 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639042.973051310 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639042.973954201 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639042.975731373 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639043.988547564 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639043.989431620 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639043.990193844 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639054.026009560 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639055.715245485 (ncf_main.py:288) eval_start : 11
+:::MLPv0.5.0 ncf 1541639064.891018629 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 11}
+:::MLPv0.5.0 ncf 1541639064.892221928 (ncf_main.py:298) eval_accuracy : {"value": 0.6324723958969116, "epoch": 11}
+:::MLPv0.5.0 ncf 1541639064.893285751 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 11}
+:::MLPv0.5.0 ncf 1541639064.894388676 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639064.895438671 (ncf_main.py:307) eval_stop : 11
+:::MLPv0.5.0 ncf 1541639064.897495270 (ncf_main.py:250) train_epoch : 12
+:::MLPv0.5.0 ncf 1541639068.386284590 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639068.620766878 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639068.621762514 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639068.623532295 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639069.652983189 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639069.653871775 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639069.655254602 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639079.759501696 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639081.394753456 (ncf_main.py:288) eval_start : 12
+:::MLPv0.5.0 ncf 1541639090.601745129 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 12}
+:::MLPv0.5.0 ncf 1541639090.602892160 (ncf_main.py:298) eval_accuracy : {"value": 0.6331583261489868, "epoch": 12}
+:::MLPv0.5.0 ncf 1541639090.603966951 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 12}
+:::MLPv0.5.0 ncf 1541639090.605060101 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639090.606139421 (ncf_main.py:307) eval_stop : 12
+:::MLPv0.5.0 ncf 1541639090.607813358 (ncf_main.py:250) train_epoch : 13
+:::MLPv0.5.0 ncf 1541639093.529235601 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541639093.761765242 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541639093.762660503 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541639093.764389277 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541639094.784854174 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541639094.785711288 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541639094.786442280 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541639104.575978756 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541639106.884737015 (ncf_main.py:288) eval_start : 13
+:::MLPv0.5.0 ncf 1541639115.941901922 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 13}
+:::MLPv0.5.0 ncf 1541639115.943205118 (ncf_main.py:298) eval_accuracy : {"value": 0.6290282011032104, "epoch": 13}
+:::MLPv0.5.0 ncf 1541639115.944553137 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 13}
+:::MLPv0.5.0 ncf 1541639115.945715904 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541639115.946871042 (ncf_main.py:307) eval_stop : 13
+:::MLPv0.5.0 ncf 1541639115.948885441 (ncf_main.py:322) run_stop : {"success": false}
+:::MLPv0.5.0 ncf 1541639122.101526499 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_8.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_8.txt
@@ -1,0 +1,187 @@
+:::MLPv0.5.0 ncf 1541633784.076412439 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541633812.331842184 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541633812.332926035 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541633840.689930201 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541633842.217522621 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541633842.384579897 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541633842.385924578 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541633842.538933277 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541633842.540210247 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541633842.541359186 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541633842.542474985 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541633842.543566227 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541633842.544742823 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541633843.494700670 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541633843.495620251 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541633843.496549845 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541633847.428571463 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541633847.429612398 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541633852.794543266 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541633862.796217203 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541633863.044460297 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541633863.045340061 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541633863.047086716 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541633864.020861387 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541633880.195640802 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541633884.594573736 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541633903.524662733 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541633903.525588751 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541633903.526331902 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541633912.792108297 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541633913.999493361 (ncf_main.py:296) eval_target : {"epoch": 0, "value": 0.635}
+:::MLPv0.5.0 ncf 1541633914.001715422 (ncf_main.py:298) eval_accuracy : {"epoch": 0, "value": 0.5355144143104553}
+:::MLPv0.5.0 ncf 1541633914.003288031 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 0, "value": 999}
+:::MLPv0.5.0 ncf 1541633914.004815102 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541633914.006219625 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541633914.010214329 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541633925.758931160 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541633926.001628876 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541633926.002696991 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541633926.004520893 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541633927.017638206 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541633927.018500805 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541633927.019226551 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541633936.503736973 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541633938.675363541 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541633947.942579508 (ncf_main.py:296) eval_target : {"epoch": 1, "value": 0.635}
+:::MLPv0.5.0 ncf 1541633947.944736719 (ncf_main.py:298) eval_accuracy : {"epoch": 1, "value": 0.5933079719543457}
+:::MLPv0.5.0 ncf 1541633947.946526766 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 1, "value": 999}
+:::MLPv0.5.0 ncf 1541633947.948253393 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541633947.950294495 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541633947.955521345 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541633951.192464828 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541633951.427693605 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541633951.428581238 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541633951.430352211 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541633952.440587044 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541633952.441425323 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541633952.442149401 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541633962.389586926 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541633964.485746145 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541633973.832741261 (ncf_main.py:296) eval_target : {"epoch": 2, "value": 0.635}
+:::MLPv0.5.0 ncf 1541633973.834342957 (ncf_main.py:298) eval_accuracy : {"epoch": 2, "value": 0.6142404079437256}
+:::MLPv0.5.0 ncf 1541633973.835930586 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 2, "value": 999}
+:::MLPv0.5.0 ncf 1541633973.837467670 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541633973.838932276 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541633973.842877150 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541633976.868446589 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541633977.108947992 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541633977.109932899 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541633977.111764193 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541633978.124878407 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541633978.125756741 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541633978.126549244 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541633987.882139444 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541633990.403650284 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541633999.752817392 (ncf_main.py:296) eval_target : {"epoch": 3, "value": 0.635}
+:::MLPv0.5.0 ncf 1541633999.754131317 (ncf_main.py:298) eval_accuracy : {"epoch": 3, "value": 0.6230350732803345}
+:::MLPv0.5.0 ncf 1541633999.755548477 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 3, "value": 999}
+:::MLPv0.5.0 ncf 1541633999.756847858 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541633999.758169174 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541633999.760797262 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541634001.934432507 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541634002.172694921 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541634002.173647642 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541634002.176377296 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541634003.209175110 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541634003.210082054 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541634003.210810661 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541634012.724496841 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541634015.359450340 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541634024.623889685 (ncf_main.py:296) eval_target : {"epoch": 4, "value": 0.635}
+:::MLPv0.5.0 ncf 1541634024.625084400 (ncf_main.py:298) eval_accuracy : {"epoch": 4, "value": 0.624255359172821}
+:::MLPv0.5.0 ncf 1541634024.626185179 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 4, "value": 999}
+:::MLPv0.5.0 ncf 1541634024.627274275 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541634024.628348112 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541634024.630026102 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541634027.304376364 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541634027.554424047 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541634027.555421829 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541634027.557218790 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541634028.599627018 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541634028.600513935 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541634028.601523399 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541634038.247190952 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541634040.204885483 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541634049.454578400 (ncf_main.py:296) eval_target : {"epoch": 5, "value": 0.635}
+:::MLPv0.5.0 ncf 1541634049.455724716 (ncf_main.py:298) eval_accuracy : {"epoch": 5, "value": 0.6309777498245239}
+:::MLPv0.5.0 ncf 1541634049.456771612 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 5, "value": 999}
+:::MLPv0.5.0 ncf 1541634049.457925081 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541634049.458989143 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541634049.460813522 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541634052.598333120 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541634052.838178158 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541634052.839139462 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541634052.840905190 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541634053.873098135 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541634053.873992443 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541634053.874759674 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541634063.560905457 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541634066.015788794 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541634075.329430342 (ncf_main.py:296) eval_target : {"epoch": 6, "value": 0.635}
+:::MLPv0.5.0 ncf 1541634075.330686569 (ncf_main.py:298) eval_accuracy : {"epoch": 6, "value": 0.6332811117172241}
+:::MLPv0.5.0 ncf 1541634075.331876755 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 6, "value": 999}
+:::MLPv0.5.0 ncf 1541634075.332991362 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541634075.334129810 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541634075.336100101 (ncf_main.py:250) train_epoch : 7
+:::MLPv0.5.0 ncf 1541634078.215678692 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541634078.458297729 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541634078.459167004 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541634078.460916281 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541634079.510891676 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541634079.511835337 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541634079.512629986 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541634089.159586430 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541634091.814576387 (ncf_main.py:288) eval_start : 7
+:::MLPv0.5.0 ncf 1541634100.890487909 (ncf_main.py:296) eval_target : {"epoch": 7, "value": 0.635}
+:::MLPv0.5.0 ncf 1541634100.891679287 (ncf_main.py:298) eval_accuracy : {"epoch": 7, "value": 0.6258655786514282}
+:::MLPv0.5.0 ncf 1541634100.892809868 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 7, "value": 999}
+:::MLPv0.5.0 ncf 1541634100.893930674 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541634100.895038366 (ncf_main.py:307) eval_stop : 7
+:::MLPv0.5.0 ncf 1541634100.896654367 (ncf_main.py:250) train_epoch : 8
+:::MLPv0.5.0 ncf 1541634103.229527712 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541634103.466492653 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541634103.467323542 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541634103.468997955 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541634104.497328281 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541634104.498208523 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541634104.498906136 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541634113.913375139 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541634116.370789051 (ncf_main.py:288) eval_start : 8
+:::MLPv0.5.0 ncf 1541634125.495560646 (ncf_main.py:296) eval_target : {"epoch": 8, "value": 0.635}
+:::MLPv0.5.0 ncf 1541634125.496621370 (ncf_main.py:298) eval_accuracy : {"epoch": 8, "value": 0.6348840594291687}
+:::MLPv0.5.0 ncf 1541634125.497645378 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 8, "value": 999}
+:::MLPv0.5.0 ncf 1541634125.498773336 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541634125.499867916 (ncf_main.py:307) eval_stop : 8
+:::MLPv0.5.0 ncf 1541634125.501574516 (ncf_main.py:250) train_epoch : 9
+:::MLPv0.5.0 ncf 1541634128.347003698 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541634128.588598967 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541634128.589591026 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541634128.591367006 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541634129.643951416 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541634129.645126343 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541634129.646170139 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541634138.920884132 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541634140.920762300 (ncf_main.py:288) eval_start : 9
+:::MLPv0.5.0 ncf 1541634150.038336277 (ncf_main.py:296) eval_target : {"epoch": 9, "value": 0.635}
+:::MLPv0.5.0 ncf 1541634150.039472580 (ncf_main.py:298) eval_accuracy : {"epoch": 9, "value": 0.6306816935539246}
+:::MLPv0.5.0 ncf 1541634150.040536165 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 9, "value": 999}
+:::MLPv0.5.0 ncf 1541634150.041595697 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541634150.042622089 (ncf_main.py:307) eval_stop : 9
+:::MLPv0.5.0 ncf 1541634150.044364929 (ncf_main.py:250) train_epoch : 10
+:::MLPv0.5.0 ncf 1541634153.084785700 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541634153.321539164 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541634153.322626829 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541634153.324467182 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541634154.330637217 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541634154.331571579 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541634154.332372904 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541634164.011516094 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541634166.685122490 (ncf_main.py:288) eval_start : 10
+:::MLPv0.5.0 ncf 1541634175.769804001 (ncf_main.py:296) eval_target : {"epoch": 10, "value": 0.635}
+:::MLPv0.5.0 ncf 1541634175.771140099 (ncf_main.py:298) eval_accuracy : {"epoch": 10, "value": 0.6350429058074951}
+:::MLPv0.5.0 ncf 1541634175.772264957 (ncf_main.py:301) eval_hp_num_neg : {"epoch": 10, "value": 999}
+:::MLPv0.5.0 ncf 1541634175.773369312 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541634175.774472713 (ncf_main.py:307) eval_stop : 10
+:::MLPv0.5.0 ncf 1541634175.776590347 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541634181.931392193 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_9.txt
+++ b/compliance/verify_submission/mlperf_submission_helper/unittest_files/10_mixed_results/result_9.txt
@@ -1,0 +1,142 @@
+:::MLPv0.5.0 ncf 1541631499.260495424 (data_preprocessing.py:139) preproc_hp_min_ratings : 20
+:::MLPv0.5.0 ncf 1541631528.275058508 (data_preprocessing.py:155) preproc_hp_num_eval : 999
+:::MLPv0.5.0 ncf 1541631528.276078463 (data_preprocessing.py:158) preproc_hp_sample_eval_replacement : true
+:::MLPv0.5.0 ncf 1541631556.569270849 (data_preprocessing.py:514) run_clear_caches 
+:::MLPv0.5.0 ncf 1541631558.095288277 (data_preprocessing.py:516) run_start 
+:::MLPv0.5.0 ncf 1541631558.260651350 (neumf_model.py:189) model_hp_mf_dim : 64
+:::MLPv0.5.0 ncf 1541631558.261936665 (neumf_model.py:191) model_hp_mlp_layer_sizes : [256, 256, 128, 64]
+:::MLPv0.5.0 ncf 1541631558.414551020 (neumf_model.py:118) opt_name : "adam"
+:::MLPv0.5.0 ncf 1541631558.415807247 (neumf_model.py:120) opt_learning_rate : 0.00395706
+:::MLPv0.5.0 ncf 1541631558.417001963 (neumf_model.py:122) opt_hp_Adam_beta1 : 0.779661
+:::MLPv0.5.0 ncf 1541631558.418153763 (neumf_model.py:124) opt_hp_Adam_beta2 : 0.895586
+:::MLPv0.5.0 ncf 1541631558.419267416 (neumf_model.py:126) opt_hp_Adam_epsilon : 1.45039e-07
+:::MLPv0.5.0 ncf 1541631558.420404434 (neumf_model.py:135) model_hp_loss_fn : "binary_cross_entropy"
+:::MLPv0.5.0 ncf 1541631559.281426907 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631559.282351732 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631559.283097506 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631563.618130684 (ncf_main.py:243) train_loop 
+:::MLPv0.5.0 ncf 1541631563.619222164 (ncf_main.py:250) train_epoch : 0
+:::MLPv0.5.0 ncf 1541631568.264500618 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631577.735880613 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631577.957475662 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631577.958349943 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631577.960924625 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631578.871345997 (data_async_generation.py:240) input_step_eval_neg_gen 
+:::MLPv0.5.0 ncf 1541631595.015643597 (ncf_main.py:288) eval_start : 0
+:::MLPv0.5.0 ncf 1541631599.068238020 (data_async_generation.py:320) eval_size : 138493000
+:::MLPv0.5.0 ncf 1541631616.733568192 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631616.734480381 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631616.735254288 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631625.623954535 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631627.058417320 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 0}
+:::MLPv0.5.0 ncf 1541631627.060239077 (ncf_main.py:298) eval_accuracy : {"value": 0.5299473404884338, "epoch": 0}
+:::MLPv0.5.0 ncf 1541631627.061510324 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 0}
+:::MLPv0.5.0 ncf 1541631627.062723875 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631627.063873053 (ncf_main.py:307) eval_stop : 0
+:::MLPv0.5.0 ncf 1541631627.066453695 (ncf_main.py:250) train_epoch : 1
+:::MLPv0.5.0 ncf 1541631637.954942942 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631638.170925140 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631638.171757221 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631638.173471928 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631639.173291922 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631639.174464464 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631639.175425291 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631648.537451267 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631650.270410061 (ncf_main.py:288) eval_start : 1
+:::MLPv0.5.0 ncf 1541631659.307844400 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 1}
+:::MLPv0.5.0 ncf 1541631659.308756351 (ncf_main.py:298) eval_accuracy : {"value": 0.5876036882400513, "epoch": 1}
+:::MLPv0.5.0 ncf 1541631659.309592724 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 1}
+:::MLPv0.5.0 ncf 1541631659.310423613 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631659.311274529 (ncf_main.py:307) eval_stop : 1
+:::MLPv0.5.0 ncf 1541631659.312756062 (ncf_main.py:250) train_epoch : 2
+:::MLPv0.5.0 ncf 1541631662.343611479 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631662.560714722 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631662.561597109 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631662.563328505 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631663.508899450 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631663.509758949 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631663.510467052 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631672.696743250 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631675.625155210 (ncf_main.py:288) eval_start : 2
+:::MLPv0.5.0 ncf 1541631684.675855875 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 2}
+:::MLPv0.5.0 ncf 1541631684.677035093 (ncf_main.py:298) eval_accuracy : {"value": 0.617013156414032, "epoch": 2}
+:::MLPv0.5.0 ncf 1541631684.678092957 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 2}
+:::MLPv0.5.0 ncf 1541631684.679159164 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631684.680258751 (ncf_main.py:307) eval_stop : 2
+:::MLPv0.5.0 ncf 1541631684.683620453 (ncf_main.py:250) train_epoch : 3
+:::MLPv0.5.0 ncf 1541631686.192053556 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631686.415297508 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631686.416174650 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631686.417960405 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631687.385180235 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631687.385957003 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631687.386636734 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631696.784683704 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631698.876183748 (ncf_main.py:288) eval_start : 3
+:::MLPv0.5.0 ncf 1541631707.906416178 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 3}
+:::MLPv0.5.0 ncf 1541631707.907561779 (ncf_main.py:298) eval_accuracy : {"value": 0.6261904835700989, "epoch": 3}
+:::MLPv0.5.0 ncf 1541631707.908753633 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 3}
+:::MLPv0.5.0 ncf 1541631707.909807205 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631707.910764217 (ncf_main.py:307) eval_stop : 3
+:::MLPv0.5.0 ncf 1541631707.912425280 (ncf_main.py:250) train_epoch : 4
+:::MLPv0.5.0 ncf 1541631710.637432575 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631710.859166145 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631710.860014200 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631710.861742735 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631711.817578554 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631711.818401098 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631711.819155693 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631720.856826782 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631723.175854445 (ncf_main.py:288) eval_start : 4
+:::MLPv0.5.0 ncf 1541631732.161775351 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 4}
+:::MLPv0.5.0 ncf 1541631732.162794590 (ncf_main.py:298) eval_accuracy : {"value": 0.6246091723442078, "epoch": 4}
+:::MLPv0.5.0 ncf 1541631732.163615465 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 4}
+:::MLPv0.5.0 ncf 1541631732.164470911 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631732.165247202 (ncf_main.py:307) eval_stop : 4
+:::MLPv0.5.0 ncf 1541631732.166882753 (ncf_main.py:250) train_epoch : 5
+:::MLPv0.5.0 ncf 1541631734.412759304 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631734.635779142 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631734.636681557 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631734.638389111 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631735.594851017 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631735.595717669 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631735.596507072 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631744.615598440 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631747.492086411 (ncf_main.py:288) eval_start : 5
+:::MLPv0.5.0 ncf 1541631756.363870144 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 5}
+:::MLPv0.5.0 ncf 1541631756.364969015 (ncf_main.py:298) eval_accuracy : {"value": 0.6296130418777466, "epoch": 5}
+:::MLPv0.5.0 ncf 1541631756.366026402 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 5}
+:::MLPv0.5.0 ncf 1541631756.367037296 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631756.367975235 (ncf_main.py:307) eval_stop : 5
+:::MLPv0.5.0 ncf 1541631756.369771481 (ncf_main.py:250) train_epoch : 6
+:::MLPv0.5.0 ncf 1541631758.621215105 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631758.845230579 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631758.846034765 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631758.847634554 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631759.813386679 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631759.814144373 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631759.814892054 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631768.872290850 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631771.607383251 (ncf_main.py:288) eval_start : 6
+:::MLPv0.5.0 ncf 1541631780.619389296 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 6}
+:::MLPv0.5.0 ncf 1541631780.620537758 (ncf_main.py:298) eval_accuracy : {"value": 0.6349273920059204, "epoch": 6}
+:::MLPv0.5.0 ncf 1541631780.621808290 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 6}
+:::MLPv0.5.0 ncf 1541631780.623294115 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631780.624791861 (ncf_main.py:307) eval_stop : 6
+:::MLPv0.5.0 ncf 1541631780.628558397 (ncf_main.py:250) train_epoch : 7
+:::MLPv0.5.0 ncf 1541631782.781100273 (data_async_generation.py:296) input_order 
+:::MLPv0.5.0 ncf 1541631783.003668547 (data_async_generation.py:314) input_size : 99385344
+:::MLPv0.5.0 ncf 1541631783.004613638 (data_async_generation.py:316) input_batch_size : 98304
+:::MLPv0.5.0 ncf 1541631783.006322145 (data_async_generation.py:347) input_order 
+:::MLPv0.5.0 ncf 1541631783.971688986 (data_async_generation.py:227) input_step_train_neg_gen 
+:::MLPv0.5.0 ncf 1541631783.972500324 (data_async_generation.py:229) input_hp_num_neg : 4
+:::MLPv0.5.0 ncf 1541631783.973114014 (data_async_generation.py:233) input_hp_sample_train_replacement : true
+:::MLPv0.5.0 ncf 1541631793.262183428 (data_async_generation.py:277) input_order 
+:::MLPv0.5.0 ncf 1541631795.851679325 (ncf_main.py:288) eval_start : 7
+:::MLPv0.5.0 ncf 1541631804.843798399 (ncf_main.py:296) eval_target : {"value": 0.635, "epoch": 7}
+:::MLPv0.5.0 ncf 1541631804.845178843 (ncf_main.py:298) eval_accuracy : {"value": 0.6357071995735168, "epoch": 7}
+:::MLPv0.5.0 ncf 1541631804.846249342 (ncf_main.py:301) eval_hp_num_neg : {"value": 999, "epoch": 7}
+:::MLPv0.5.0 ncf 1541631804.847424507 (ncf_main.py:305) eval_hp_num_users : 138493
+:::MLPv0.5.0 ncf 1541631804.848529577 (ncf_main.py:307) eval_stop : 7
+:::MLPv0.5.0 ncf 1541631804.850411892 (ncf_main.py:322) run_stop : {"success": true}
+:::MLPv0.5.0 ncf 1541631811.008860111 (ncf_main.py:328) run_final 

--- a/compliance/verify_submission/mlperf_submission_helper/utils.py
+++ b/compliance/verify_submission/mlperf_submission_helper/utils.py
@@ -1,11 +1,14 @@
 import os
 
+
 def get_subdirs(parent_path):
-    """Return a list of (name, path) tuples of direct subdirectories of
+  """Return a list of (name, path) tuples of direct subdirectories of
+
     parent_path, where each tuple corresponds to one subdirectory. Files
     in the parent_path are excluded from the output.
     """
-    entries = os.listdir(parent_path)
-    subdirs = [(entry, os.path.join(parent_path, entry))
-                    for entry in entries if os.path.isdir(entry)]
-    return subdirs
+  entries = os.listdir(parent_path)
+  subdirs = [(entry, os.path.join(parent_path, entry))
+             for entry in entries
+             if os.path.isdir(entry)]
+  return subdirs

--- a/compliance/verify_submission/mlperf_submission_helper/verify_submission.py
+++ b/compliance/verify_submission/mlperf_submission_helper/verify_submission.py
@@ -9,73 +9,85 @@ import report
 
 
 def verify_submission(args):
-    root_dir = args.root
-    public_key = args.public_key
-    private_key = args.private_key
-    encrypt_out = args.encrypt_out
-    decrypt_out = args.decrypt_out
+  root_dir = args.root
+  public_key = args.public_key
+  private_key = args.private_key
+  encrypt_out = args.encrypt_out
+  decrypt_out = args.decrypt_out
 
-    # validate args
-    if any([public_key, encrypt_out]) and not all([public_key, encrypt_out]):
-        print("--encrypt-key and --encrypt-out must be present togetger.")
-        sys.exit(1)
-    if any([private_key, decrypt_out]) and not all([private_key, decrypt_out]):
-        print("--decrypt-key and --decrypt-out must be present together.")
-        sys.exit(1)
-    if all([private_key, public_key]):
-        print("--encrypt-key and --decrypt-key cannot be present together.")
-        sys.exit(1)
+  # validate args
+  if any([public_key, encrypt_out]) and not all([public_key, encrypt_out]):
+    print("--encrypt-key and --encrypt-out must be present togetger.")
+    sys.exit(1)
+  if any([private_key, decrypt_out]) and not all([private_key, decrypt_out]):
+    print("--decrypt-key and --decrypt-out must be present together.")
+    sys.exit(1)
+  if all([private_key, public_key]):
+    print("--encrypt-key and --decrypt-key cannot be present together.")
+    sys.exit(1)
 
-    if any([public_key, private_key]):
-        import crypto
+  if any([public_key, private_key]):
+    import crypto
 
-    # if decrypt-key is provided, then decrypt the submission, save it to
-    # decrypt-out and point submission root to the decrypted directory
-    if private_key:
-        try:
-            crypto.decrypt_submission(private_key, root_dir, decrypt_out)
-        except Exception as e:
-            print("Unable to decrypt submission: {}".format(str(e)))
-            sys.exit(1)
-        print("Decrypted submission saved at {}".format(decrypt_out))
-        root_dir = decrypt_out
+  # if decrypt-key is provided, then decrypt the submission, save it to
+  # decrypt-out and point submission root to the decrypted directory
+  if private_key:
+    try:
+      crypto.decrypt_submission(private_key, root_dir, decrypt_out)
+    except Exception as e:
+      print("Unable to decrypt submission: {}".format(str(e)))
+      sys.exit(1)
+    print("Decrypted submission saved at {}".format(decrypt_out))
+    root_dir = decrypt_out
 
-    # perform verifications and extract results
-    checks = submission_checks.SubmissionChecks()
-    checks.verify_dirs_and_files(root_dir)
-    checks.verify_metadata()
-    checks.compile_results()
+  # perform verifications and extract results
+  checks = submission_checks.SubmissionChecks()
+  checks.verify_dirs_and_files(root_dir)
+  checks.verify_metadata()
+  checks.compile_results()
 
-    checks.report.print_report()
-    checks.report.print_results()
+  checks.report.print_report()
+  checks.report.print_results()
 
-    # if encrypt-key is provided, then encrypt the submission
-    # and save it to encrypt-out
-    if public_key:
-        try:
-            crypto.encrypt_submission(public_key, root_dir, encrypt_out)
-        except Exception as e:
-            print("Unable to encrypt submission: {}".format(str(e)))
-            sys.exit(1)
-        print("Encrypted submission saved at {}".format(encrypt_out))
+  # if encrypt-key is provided, then encrypt the submission
+  # and save it to encrypt-out
+  if public_key:
+    try:
+      crypto.encrypt_submission(public_key, root_dir, encrypt_out)
+    except Exception as e:
+      print("Unable to encrypt submission: {}".format(str(e)))
+      sys.exit(1)
+    print("Encrypted submission saved at {}".format(encrypt_out))
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Verify MLPerf submission.")
-    parser.add_argument("root", metavar="SUBMISSION_ROOT",
-                        help="submission root directory")
-    parser.add_argument("--encrypt-key", dest="public_key", default=None,
-                        help="public key for encrypting log files")
-    parser.add_argument("--encrypt-out", dest="encrypt_out", default=None,
-                        help="output path for encrypted submission")
-    parser.add_argument("--decrypt-key", dest="private_key", default=None,
-                        help="private key for decrypting log files")
-    parser.add_argument("--decrypt-out", dest="decrypt_out", default=None,
-                        help="output path for decrypted submission")
-    args = parser.parse_args()
+  parser = argparse.ArgumentParser(description="Verify MLPerf submission.")
+  parser.add_argument(
+      "root", metavar="SUBMISSION_ROOT", help="submission root directory")
+  parser.add_argument(
+      "--encrypt-key",
+      dest="public_key",
+      default=None,
+      help="public key for encrypting log files")
+  parser.add_argument(
+      "--encrypt-out",
+      dest="encrypt_out",
+      default=None,
+      help="output path for encrypted submission")
+  parser.add_argument(
+      "--decrypt-key",
+      dest="private_key",
+      default=None,
+      help="private key for decrypting log files")
+  parser.add_argument(
+      "--decrypt-out",
+      dest="decrypt_out",
+      default=None,
+      help="output path for decrypted submission")
+  args = parser.parse_args()
 
-    verify_submission(args)
+  verify_submission(args)
 
 
 if __name__ == "__main__":
-    main()
+  main()


### PR DESCRIPTION
**Not sure you should accept this** but what is out there is broken.  I made a mess by reformatting and I made these changes just so I could get a submission to pass according to the rules.  What has been fixed:
  - For NCF
     - entries that fail to converge are marked as INFINITE (9999999.99 or something this is a cheap trick and -1 would also be fine but the idea is anything that fails should be INFINIT and count as the worst run beyond NCF)
    - For the aggregation I take the first 50 that pass, but this may not be the first 50 by the timestamp and I suggest that be fixed but really I think the 50 fastest might be better and I did notice a range if I average all passing vs. a random 50 and I am too lazy to sort the logs by the timestamp in the logs.
     -  Error if I do not find 100 total entries
     -  Error if I do not find 50 that pass
  - Call mlp_compliance as a module not a subprocess so we can get the data cleanly and even get more info that would help in determining how to aggregate data.
 - Removed power and other fields that are optional from being required to match the spec.
 - Code clean up (too much to do really, where are the unit tests?????) 
   - removed from constants import * (we don't allow this where I work for most things)   
   - formatted to 2 spaces which is our standard and I guess I like it and with only 80 spaces I hate to waste 2.
   - reduced line wrapping in some areas.

In my view this code is still in need of serious TLC.  I am not saying I made it much better but it at least works now better than before and if I had more than 30 minutes I could do much better.

I also made a total mess by reformatting but we use 2 spaces and having my IDE all red makes it hard to fix anything.


Also the compliance directory needs updated but I am not skilled with submodules.