### PR TITLE
Added bytes object decoding to fix verification script fails.

### DIFF
--- a/compliance/verify_submission/mlperf_submission_helper/checks.py
+++ b/compliance/verify_submission/mlperf_submission_helper/checks.py
@@ -189,6 +189,7 @@ class SubmissionChecks(object):
                 os.path.dirname(__file__), "mlp_compliance/mlp_compliance.py")
         output_str = subprocess.check_output(
                 ["python", mlp_compliance_script, "--level", str(level), log_file])
+        output_str = output_str.decode('utf-8')
         success_flag = False
         result_time = None
         for line in output_str.split("\n"):


### PR DESCRIPTION
Without this fix the verification script fails because subprocess.check_output returns a bytes object instead of a string. This results in an exception being thrown at line 194, because calling 'split' on a bytes object requires a bytes argument while a string argument is currently passed. Decoding the bytes object into a string solves this problem