### PR TITLE
data_download.py consistent with process_data.py for transformers

### DIFF
--- a/translation/tensorflow/transformer/data_download.py
+++ b/translation/tensorflow/transformer/data_download.py
@@ -73,6 +73,7 @@ VOCAB_FILE = "vocab.ende.%d" % _TARGET_VOCAB_SIZE
 
 # Strings to inclue in the generated files.
 _PREFIX = "wmt32k"
+_ENCODE_TAG = "encoded"
 _TRAIN_TAG = "train"
 _EVAL_TAG = "dev"  # Following WMT and Tensor2Tensor conventions, in which the
                    # evaluation datasets are tagged as "dev" for development.
@@ -307,7 +308,7 @@ def encode_and_save_files(
 def shard_filename(path, tag, shard_num, total_shards):
   """Create filename for data shard."""
   return os.path.join(
-      path, "%s-%s-%.5d-of-%.5d" % (_PREFIX, tag, shard_num, total_shards))
+      path, "%s-%s-%s-%.5d-of-%.5d" % (_PREFIX, _ENCODE_TAG, tag, shard_num, total_shards))
 
 
 def shuffle_records(fname):


### PR DESCRIPTION
The file pattern in the train_input_fn and eval_input_fn under translation/tensorflow/transformer/utils/dataset.py requires the word `encoded` be present in the file names. When the files were downloaded using the data_download.py provided with transformer, the files do not have `encoded` as part of their string. Fixing the `data_download.py`  to match `process_data.py` similar to #173 ,  so one can run the transformer code without running into this issue