### PR TITLE
[data_generation] fix data_gen.sh

### DIFF
--- a/data_generation/fractal_graph_expansions/data_gen.sh
+++ b/data_generation/fractal_graph_expansions/data_gen.sh
@@ -6,4 +6,4 @@ DATA_DIR=${DATA_DIR:-/data/cache}
 DATA_PATH=${DATA_DIR}/${DATASET}x${USER_MUL}x${ITEM_MUL}/
 
 mkdir -p ${DATA_PATH}
-python run_expansion.py --input_csv_file ${DATA_DIR}/${DATASET}/ratings.csv --num_row_multiplier ${USER_MUL} --num_col_multiplier ${ITEM_MUL} --output_prefix ${DATA_PATH}
+python3 run_expansion.py --input_csv_file ${DATA_DIR}/${DATASET}/ratings.csv --num_row_multiplier ${USER_MUL} --num_col_multiplier ${ITEM_MUL} --output_prefix ${DATA_PATH}


### PR DESCRIPTION
#L9  python run_expansion.py error occurs.

https://github.com/ai-kase/training/blob/master/data_generation/fractal_graph_expansions/run_expansion.py#L28
import error.

absl works only in python3. (not suppot python2)