### PR TITLE
Enhancements, fixings, and cleanups for mllog package

### DIFF
--- a/compliance/mllog/README.md
+++ b/compliance/mllog/README.md
@@ -8,7 +8,7 @@ Use one of the following ways to install.
 
 ```sh
 git clone https://github.com/mlperf/training.git
-pip install -e training/compliance/mllog
+pip install -e training/compliance
 ```
 
 - Install from github at a specific commit (Replace COMMIT_HASH with actual commit hash, the double quotes are needed):

--- a/compliance/mllog/README.md
+++ b/compliance/mllog/README.md
@@ -1,0 +1,31 @@
+# MLLog
+
+## Install
+
+Use one of the following ways to install.
+
+- For development, you may download the latest version and install from local path:
+
+```sh
+git clone https://github.com/mlperf/training.git
+pip install -e training/compliance/mllog
+```
+
+- Install from github at a specific commit (Replace COMMIT_HASH with actual commit hash, the double quotes are needed):
+  ```
+  pip install "git+https://github.com/mlperf/training@COMMIT_HASH#subdirectory=compliance"
+  ```
+
+Uninstall:
+
+```sh
+pip uninstall mlperf_compliance
+```
+
+## Use
+
+[Here](examples/dummy_example.py) is an example of how to use the `mllog` package in benchmark codes. You can run the example by:
+
+```sh
+python3 -m mllog.examples.dummy_example 
+```

--- a/compliance/mllog/__init__.py
+++ b/compliance/mllog/__init__.py
@@ -15,13 +15,72 @@
 
 import logging
 import sys
+import threading
 
 from mllog import mllog
 
 
+# _lock is for serializing access to shared data structures in this module.
+_lock = threading.RLock()
+
+# mllogger is a logger shareable across modules.
 mllogger = mllog.MLLogger()
 
 
 def get_mllogger():
-  """Get the shared MLLogger instance"""
+  """Get the shared logger."""
   return mllogger
+
+def config(**kwargs):
+  """Configure the shared logger.
+  Optional keyword arguments:
+    logger: a logging.Logger instance. Customize the logger to change
+      the logging behavior (e.g. logging to a file, etc.)
+    default_namespace: the default namespace to use if one isn't provided.
+    default_stack_offset: the default depth to go into the stack to find the
+      call site.
+    default_clear_line: the default behavior of line clearing (i.e. print
+      an extra new line to clear any pre-existing text in the log line).
+    root_dir: directory prefix which will be trimmed when reporting calling
+      file for logging.
+  """
+  if _lock:
+    _lock.acquire()
+  try:
+    logger = kwargs.pop("logger", None)
+    if logger is not None:
+      if not isinstance(logger, logging.Logger):
+        raise ValueError("'logger' must be an instance of 'logging.Logger'.")
+      if logger.name == mllogger.logger.name:
+        raise ValueError("'logger' should not be the same as the default " +
+                         "logger to avoid unexpected behavior. Consider " +
+                         "using a different name for the logger.")
+      mllogger.logger = logger
+
+    default_namespace = kwargs.pop("default_namespace", None)
+    if default_namespace is not None:
+      if not isinstance(default_namespace, str):
+        raise ValueError("'default_namespace' must be a string.")
+      mllogger.default_namespace = default_namespace
+
+    default_stack_offset = kwargs.pop("default_stack_offset", None)
+    if default_stack_offset is not None:
+      if not isinstance(default_stack_offset, int):
+        raise ValueError("'default_stack_offset' must be an integer.")
+      mllogger.default_stack_offset = default_stack_offset
+
+    default_clear_line = kwargs.pop("default_clear_line", None)
+    if default_clear_line is not None:
+      if not isinstance(default_clear_line, bool):
+        raise ValueError("'default_clear_line' must be a boolean value.")
+      mllogger.default_clear_line = default_clear_line
+
+    root_dir = kwargs.pop("root_dir", None)
+    if root_dir is not None:
+      if not isinstance(root_dir, str):
+        raise ValueError("'root_dir' must be a string.")
+      mllogger.root_dir = root_dir
+
+  finally:
+    if _lock:
+      _lock.release()

--- a/compliance/mllog/__init__.py
+++ b/compliance/mllog/__init__.py
@@ -36,6 +36,9 @@ def config(**kwargs):
   Optional keyword arguments:
     logger: a logging.Logger instance. Customize the logger to change
       the logging behavior (e.g. logging to a file, etc.)
+    filename: a log file to use. If set, a default file handler will be added
+      to the logger so it can log to the specified file. For more advanced
+      customizations, please set the 'logger' parameter instead.
     default_namespace: the default namespace to use if one isn't provided.
     default_stack_offset: the default depth to go into the stack to find the
       call site.
@@ -56,6 +59,14 @@ def config(**kwargs):
                          "logger to avoid unexpected behavior. Consider " +
                          "using a different name for the logger.")
       mllogger.logger = logger
+
+    log_file = kwargs.pop("filename", None)
+    if log_file is not None:
+      if not isinstance(log_file, str):
+        raise ValueError("'filename' must be a string.")
+      _file_handler = logging.FileHandler(log_file)
+      _file_handler.setLevel(logging.INFO)
+      mllogger.logger.addHandler(_file_handler)
 
     default_namespace = kwargs.pop("default_namespace", None)
     if default_namespace is not None:

--- a/compliance/mllog/__init__.py
+++ b/compliance/mllog/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import logging
+import sys
+
+from mllog import mllog
+
+
+mllogger = mllog.MLLogger()
+
+
+def get_mllogger():
+  """Get the shared MLLogger instance"""
+  return mllogger

--- a/compliance/mllog/constants.py
+++ b/compliance/mllog/constants.py
@@ -19,6 +19,7 @@
 # NOTE: Keep string values in alphabetical order under each section.
 
 # Constant values - log settings
+DEFAULT_LOGGER_NAME = "mllog_default"
 DEFAULT_NAMESPACE = ""
 
 # Constant values - log event type

--- a/compliance/mllog/constants.py
+++ b/compliance/mllog/constants.py
@@ -1,0 +1,97 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Master list of constants in MLPerf log
+"""
+
+# NOTE: Keep string values in alphabetical order under each section.
+
+# Constant values - log settings
+DEFAULT_NAMESPACE = ""
+
+# Constant values - log event type
+INTERVAL_END = "INTERVAL_END"
+INTERVAL_START = "INTERVAL_START"
+POINT_IN_TIME = "POINT_IN_TIME"
+
+# Constant values - benchmark name
+GNMT = "gnmt"
+MASKRCNN = "maskrcnn"
+MINIGO = "minigo"
+NCF = "ncf"
+RESNET = "resnet"
+SSD = "ssd"
+TRANSFORMER = "transformer"
+
+# Constant values - model info
+ADAM = "adam"
+LARS = "lars"
+LAZY_ADAM = "lazy_adam"
+SGD = "sgd"
+
+# Log keys - submission info
+SUBMISSION_BENCHMARK = "submission_benchmark"
+SUBMISSION_DIVISION = "submission_division"
+SUBMISSION_ENTRY = "submission_entry"
+SUBMISSION_ORG = "submission_org"
+SUBMISSION_PLATFORM = "submission_platform"
+SUBMISSION_POC_NAME = "submission_poc_name"
+SUBMISSION_POC_EMAIL = "submission_poc_email"
+SUBMISSION_STATUS = "submission_status"
+
+# Log keys - timing info
+BLOCK_START = "block_start"
+BLOCK_STOP = "block_stop"
+EPOCH_START = "epoch_start"
+EPOCH_STOP = "epoch_stop"
+EVAL_START = "eval_start"
+EVAL_STOP = "eval_stop"
+INIT_START = "init_start"
+INIT_STOP = "init_stop"
+RUN_START = "run_start"
+RUN_STOP = "run_stop"
+
+# Log keys - common run info
+CACHE_CLEAR = "cache_clear"
+EVAL_ACCURACY = "eval_accuracy"
+
+# Log kyes - model hyperparameters
+GLOBAL_BATCH_SIZE = "global_batch_size"
+LARS_EPSILON = "lars_epsilon"
+LARS_OPT_END_LR = "lars_opt_end_learning_rate"
+LARS_OPT_LR_DECAY_POLY_POWER = "lars_opt_learning_rate_decay_poly_power"
+LARS_OPT_LR_DECAY_STEPS = "lars_opt_learning_rate_decay_steps"
+LARS_OPT_WEIGHT_DECAY = "lars_opt_weight_decay"
+MAX_SAMPLES = "max_samples"
+MAX_SEQUENCE_LENGTH = "max_sequence_length"
+MODEL_BN_SPAN = "model_bn_span"
+NUM_IMAGE_CANDIDATES = "num_image_candidates"
+OPT_ADAM_BETA_1 = "opt_adam_beta_1"
+OPT_ADAM_BETA_2 = "opt_adam_beta_2"
+OPT_ADAM_EPSILON = "opt_adam_epsilon"
+OPT_NAME = "opt_name"
+OPT_BASE_LR = "opt_base_learning_rate"
+OPT_LR_ALT_DECAY_FUNC = "opt_learning_rate_alt_decay_func"
+OPT_LR_ALT_WARMUP_FUNC = "opt_learning_rate_alt_warmup_func"
+OPT_LR_DECAY_BOUNDARY_EPOCHS = "opt_learning_rate_decay_boundary_epochs"
+OPT_LR_DECAY_BOUNDARY_STEPS = "opt_learning_rate_decay_boundary_steps"
+OPT_LR_DECAY_FACTOR = "opt_learning_rate_decay_factor"
+OPT_LR_DECAY_INTERVAL = "opt_learning_rate_decay_interval"
+OPT_LR_DECAY_STEPS = "opt_learning_rate_decay_steps"
+OPT_LR_REMAIN_STEPS = "opt_learning_rate_remain_steps"
+OPT_LR_WARMUP_EPOCHS = "opt_learning_rate_warmup_epochs"
+OPT_LR_WARMUP_FACTOR = "opt_learning_rate_warmup_factor"
+OPT_LR_WARMUP_STEPS = "opt_learning_rate_warmup_steps"
+OPT_WEIGHT_DECAY = "opt_weight_decay"

--- a/compliance/mllog/constants.py
+++ b/compliance/mllog/constants.py
@@ -42,6 +42,10 @@ LARS = "lars"
 LAZY_ADAM = "lazy_adam"
 SGD = "sgd"
 
+# Constant values - metadata info
+ABORTED = "aborted"
+SUCCESS = "success"
+
 # Log keys - submission info
 SUBMISSION_BENCHMARK = "submission_benchmark"
 SUBMISSION_DIVISION = "submission_division"
@@ -96,3 +100,9 @@ OPT_LR_WARMUP_EPOCHS = "opt_learning_rate_warmup_epochs"
 OPT_LR_WARMUP_FACTOR = "opt_learning_rate_warmup_factor"
 OPT_LR_WARMUP_STEPS = "opt_learning_rate_warmup_steps"
 OPT_WEIGHT_DECAY = "opt_weight_decay"
+
+# Log metadata keys
+EPOCH_COUNT = "epoch_count"
+EPOCH_NUM = "epoch_num"
+FIRST_EPOCH_NUM = "first_epoch_num"
+STATUS = "status"

--- a/compliance/mllog/examples/__init__.py
+++ b/compliance/mllog/examples/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/compliance/mllog/examples/dummy_example.py
+++ b/compliance/mllog/examples/dummy_example.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import sys
 
 import mllog
 from mllog import constants
@@ -30,22 +31,37 @@ def dummy_example():
   # Customize mllogger configuration
   # These configurations only need to be set Once in your entire program.
   # Try tweaking the following configurations to see the difference.
-  # Customize mllogger.logger to use a file in addition to stdout.
-  # You may replace mllogger.logger with any logging.Logger instance.
+  #   logger: Customize the underlying logger to change the logging behavior.
+  #   default_namespace: the default namespace to use if one isn't provided.
+  #   default_stack_offset: the default depth to go into the stack to find
+  #     the call site.
+  #   default_clear_line: the default behavior of line clearing (i.e. print
+  #     an extra new line to clear any pre-existing text in the log line).
+  #   root_dir: directory prefix which will be trimmed when reporting calling
+  #     file for logging.
+
+  # Customize the underlying logger to use a file in addition to stdout.
+  # You may pass a logging.Logger instance to mllog.config().
+  # Notice that proper log level needs to be set for both logger and handler.
+  logger = logging.getLogger("custom_logger")
+  logger.setLevel(logging.DEBUG)
+  # add file handler for file logging
   _file_handler = logging.FileHandler("example.log")
   _file_handler.setLevel(logging.DEBUG)
-  mllogger.logger.addHandler(_file_handler)
-  # the default namespace to use if one isn't provided.
-  mllogger.default_namespace = "worker1"
-  # the default depth to go into the stack to find the call site.
-  mllogger.default_stack_offset = 1
-  # the default behavior of line clearing (i.e. print an extra new line to
-  # clear any pre-existing text in the log line).
-  mllogger.default_clear_line = False
-  # directory prefix which will be trimmed when reporting calling file for
-  # logging.
-  mllogger.root_dir = os.path.normpath(
-      os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+  logger.addHandler(_file_handler)
+  # add stream handler for stdout logging
+  _stream_handler = logging.StreamHandler(stream=sys.stdout)
+  _stream_handler.setLevel(logging.INFO)
+  logger.addHandler(_stream_handler)
+
+  # Set logger configurations
+  mllog.config(
+      logger=logger,
+      default_namespace = "worker1",
+      default_stack_offset = 1,
+      default_clear_line = False,
+      root_dir = os.path.normpath(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..")))
 
   # Example log messages
   # The methods to use are "start", "end", and "event".

--- a/compliance/mllog/examples/dummy_example.py
+++ b/compliance/mllog/examples/dummy_example.py
@@ -32,6 +32,9 @@ def dummy_example():
   # These configurations only need to be set Once in your entire program.
   # Try tweaking the following configurations to see the difference.
   #   logger: Customize the underlying logger to change the logging behavior.
+  #   filename: a log file to use. If set, a default file handler will be added
+  #     to the logger so it can log to the specified file. For more advanced
+  #     customizations, please set the 'logger' parameter instead.
   #   default_namespace: the default namespace to use if one isn't provided.
   #   default_stack_offset: the default depth to go into the stack to find
   #     the call site.
@@ -41,22 +44,29 @@ def dummy_example():
   #     file for logging.
 
   # Customize the underlying logger to use a file in addition to stdout.
+  # 1. Simple way
+  # Provide a filename, this adds a log file with default behavior.
+  mllog.config(filename="example_simple.log")
+  # 2. Advanced way
   # You may pass a logging.Logger instance to mllog.config().
-  # Notice that proper log level needs to be set for both logger and handler.
-  logger = logging.getLogger("custom_logger")
-  logger.setLevel(logging.DEBUG)
-  # add file handler for file logging
-  _file_handler = logging.FileHandler("example.log")
-  _file_handler.setLevel(logging.DEBUG)
-  logger.addHandler(_file_handler)
-  # add stream handler for stdout logging
-  _stream_handler = logging.StreamHandler(stream=sys.stdout)
-  _stream_handler.setLevel(logging.INFO)
-  logger.addHandler(_stream_handler)
+  # To use the advanced way, comment out the "Simple way" above and uncomment
+  # the followings:
+  #
+  # # Notice that proper log level needs to be set for both logger and handler.
+  # logger = logging.getLogger("custom_logger")
+  # logger.setLevel(logging.DEBUG)
+  # # add file handler for file logging
+  # _file_handler = logging.FileHandler("example_advanced.log")
+  # _file_handler.setLevel(logging.DEBUG)
+  # logger.addHandler(_file_handler)
+  # # add stream handler for stdout logging
+  # _stream_handler = logging.StreamHandler(stream=sys.stdout)
+  # _stream_handler.setLevel(logging.INFO)
+  # logger.addHandler(_stream_handler)
+  # mllog.config(logger=logger)
 
-  # Set logger configurations
+  # Set other logger configurations
   mllog.config(
-      logger=logger,
       default_namespace = "worker1",
       default_stack_offset = 1,
       default_clear_line = False,
@@ -67,10 +77,10 @@ def dummy_example():
   # The methods to use are "start", "end", and "event".
   # You may check out the detailed APIs in mllog.mllog.
   # Try to use the keys from mllog.constants to avoid wrong keys.
-  mllogger.start(constants.RUN_START, None)
-  mllogger.event(constants.GLOBAL_BATCH_SIZE, 1024)
-  mllogger.event(constants.EVAL_ACCURACY, 0.99, clear_line=True)
-  mllogger.end(constants.RUN_STOP, None)
+  mllogger.start(key=constants.RUN_START)
+  mllogger.event(key=constants.GLOBAL_BATCH_SIZE, value=1024)
+  mllogger.event(key=constants.EVAL_ACCURACY, value=0.99, clear_line=True)
+  mllogger.end(key=constants.RUN_STOP)
 
 
 if __name__ == "__main__":

--- a/compliance/mllog/examples/dummy_example.py
+++ b/compliance/mllog/examples/dummy_example.py
@@ -1,0 +1,61 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import logging
+import os
+
+import mllog
+from mllog import constants
+
+
+def dummy_example():
+  """Example usage of mllog"""
+
+  # Get the mllogger instance, this needs to be called in every module that
+  # needs logging
+  mllogger = mllog.get_mllogger()
+
+  # Customize mllogger configuration
+  # These configurations only need to be set Once in your entire program.
+  # Try tweaking the following configurations to see the difference.
+  # Customize mllogger.logger to use a file in addition to stdout.
+  # You may replace mllogger.logger with any logging.Logger instance.
+  _file_handler = logging.FileHandler("example.log")
+  _file_handler.setLevel(logging.DEBUG)
+  mllogger.logger.addHandler(_file_handler)
+  # the default namespace to use if one isn't provided.
+  mllogger.default_namespace = "worker1"
+  # the default depth to go into the stack to find the call site.
+  mllogger.default_stack_offset = 1
+  # the default behavior of line clearing (i.e. print an extra new line to
+  # clear any pre-existing text in the log line).
+  mllogger.default_clear_line = False
+  # directory prefix which will be trimmed when reporting calling file for
+  # logging.
+  mllogger.root_dir = os.path.normpath(
+      os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+
+  # Example log messages
+  # The methods to use are "start", "end", and "event".
+  # You may check out the detailed APIs in mllog.mllog.
+  # Try to use the keys from mllog.constants to avoid wrong keys.
+  mllogger.start(constants.RUN_START, None)
+  mllogger.event(constants.GLOBAL_BATCH_SIZE, 1024)
+  mllogger.event(constants.EVAL_ACCURACY, 0.99, clear_line=True)
+  mllogger.end(constants.RUN_STOP, None)
+
+
+if __name__ == "__main__":
+  dummy_example()

--- a/compliance/mllog/mllog.py
+++ b/compliance/mllog/mllog.py
@@ -117,6 +117,8 @@ def _encode_log(namespace, time_ms, event_type, key, value, call_site):
     event_type: one of: 'INTERVAL_START', 'INTERVAL_END', 'POINT_IN_TIME'
     key: the name of the thing being logged.
     value: a json value.
+    call_site: a json pointing to the source code logging the event;
+        (e.g {"file": "train.py", "lineno": 42})
   Returns:
     A string log like, i.e. ":::MLLog { ..."
   """

--- a/compliance/mllog/mllog.py
+++ b/compliance/mllog/mllog.py
@@ -173,7 +173,7 @@ class MLLogger(object):
     """Create a default logger.
     The default logger prints INFO level messages to stdout.
     """
-    logger = logging.getLogger('mllog')
+    logger = logging.getLogger(constants.DEFAULT_LOGGER_NAME)
     logger.setLevel(logging.INFO)
     _stream_handler = logging.StreamHandler(stream=sys.stdout)
     _stream_handler.setLevel(logging.INFO)

--- a/compliance/mllog/mllog.py
+++ b/compliance/mllog/mllog.py
@@ -1,4 +1,4 @@
-# Copyright 2018 MLBenchmark Group. All Rights Reserved.
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,38 +29,31 @@ import sys
 import time
 import timeit
 
-_PREFIX = ':::MLLOG'
-PATTERN = re.compile('[a-zA-Z0-9]+')
+from mllog import constants
 
-LOG_FILE = os.getenv('COMPLIANCE_FILE')
-LOGGER = logging.getLogger('mlperf_compliance')
-LOGGER.setLevel(logging.DEBUG)
-
-_STREAM_HANDLER = logging.StreamHandler(stream=sys.stdout)
-_STREAM_HANDLER.setLevel(logging.INFO)
-LOGGER.addHandler(_STREAM_HANDLER)
-
-if LOG_FILE:
-  _FILE_HANDLER = logging.FileHandler(LOG_FILE)
-  _FILE_HANDLER.setLevel(logging.DEBUG)
-  LOGGER.addHandler(_FILE_HANDLER)
-else:
-  _STREAM_HANDLER.setLevel(logging.DEBUG)
+LOG_TEMPLATE = ':::MLLOG {log_json}'
 
 
 def get_caller(stack_index=2, root_dir=None):
+  """Get caller's file and line number information.
+  Args:
+    stack_index: a stack_index of 2 will provide the caller of the
+      function calling this function. Notice that stack_index of 2
+      or more will fail if called from global scope.
+    root_dir: the root dir prefixed to the file name. The root_dir
+      will be trimmed from the file name in the output.
+  Returns:
+    Call site info in a dictionary with these fields:
+      "file": (string) file path
+      "lineno": (int) line number
+  """
   caller = inspect.getframeinfo(inspect.stack()[stack_index][0])
 
   # Trim the filenames for readability.
   filename = caller.filename
   if root_dir is not None:
     filename = re.sub('^' + root_dir + '/', '', filename)
-  return (filename, caller.lineno)
-
-
-# :::MLL 1556733699.71 run_start: {"value": null,
-# "metadata": {"lineno": 77, "file": main.py}}
-LOG_TEMPLATE = ':::MLL {:.3f} {}: {{"value": {}, "metadata": {}}}'
+  return {"file": filename, "lineno": caller.lineno}
 
 
 def _now_as_str():
@@ -68,9 +61,9 @@ def _now_as_str():
   return datetime.datetime.now().strftime('%H:%M:%S.%f')
 
 
-def _current_time_ns():
-  """Returns current nanoseconds since epoch."""
-  return time.time() * 1000 * 1000 * 1000
+def _current_time_ms():
+  """Returns current milliseconds since epoch."""
+  return int(time.time() * 1e3)
 
 
 def _try_float(value):
@@ -116,98 +109,156 @@ def _to_ordered_json(kv_pairs):
     return '[convert-error: {kv_str}]'.format(kv_str=str(kv_pairs))
 
 
-def _encode_log(namespace, time_ns, event_type, key, log_value):
+def _encode_log(namespace, time_ms, event_type, key, value, call_site):
   """Encodes an MLEvent as a string log line.
   Args:
     namespace: provides structure, e.g. "GPU0".
-    time_ns: nano seconds since unix epoch.
+    time_ms: milliseconds since unix epoch.
     event_type: one of: 'INTERVAL_START', 'INTERVAL_END', 'POINT_IN_TIME'
     key: the name of the thing being logged.
-    log_value: a json value.
+    value: a json value.
   Returns:
     A string log like, i.e. ":::MLLog { ..."
   """
-  json_val = {
-      'namespace': str(namespace),
-      'time_ns': int(time_ns),
-      'event_type': str(event_type),
-      'key': str(key),
-      'value': str(log_value)
-  }
-  encoded = _to_ordered_json(json_val.items())
-  return '{} {}'.format(_PREFIX, encoded)
+  # preserve the order of key-values
+  ordered_key_val_pairs = [
+    ('namespace', namespace),
+    ('time_ms', time_ms),
+    ('event_type', event_type),
+    ('key', key),
+    ('value', value),
+    ('call_site', call_site)
+  ]
+  encoded = _to_ordered_json(ordered_key_val_pairs)
+  return LOG_TEMPLATE.format(log_json=encoded)
 
 
 class MLLogger(object):
-  """Creates a new logger.
-  This allows logging of MLEvents through stdout.
-  """
+  """MLPerf logging helper."""
 
-  def __init__(self, default_namespace='', log_info=True, log_file=None):
-    """Create a new logger.
+  def __init__(self,
+               logger=None,
+               default_namespace=constants.DEFAULT_NAMESPACE,
+               default_stack_offset=1,
+               default_clear_line=False,
+               root_dir=None):
+    """Create a new MLLogger.
     Args:
+      logger: a logging.Logger instance. If not specified, a default logger
+        will be used which prints to stdout. Customize the logger to change
+        the logging behavior (e.g. logging to a file, etc.)
       default_namespace: the default namespace to use if one isn't provided.
-      log_info: True if log lines should be printed to LOGGER.info()
-      log_file: an optional file object which to also write loglines to.
+      default_stack_offset: the default depth to go into the stack to find the
+        call site. Default value is 1.
+      default_clear_line: the default behavior of line clearing (i.e. print
+        an extra new line to clear any pre-existing text in the log line).
+      root_dir: directory prefix which will be trimmed when reporting calling
+        file for logging.
     """
-    self.default_namespace = default_namespace
-    self.log_info = log_info
-    self.log_file = log_file
+    if logger is None:
+      self.logger = self._get_default_logger()
+    elif not isinstance(logger, logging.Logger):
+      raise ValueError("logger must be a `logging.Logger` instance.")
+    else:
+      self.logger = logger
 
-  def _log_helper(self, key, log_value, namespace, event_type,
-                  time_ns=None):
+    self.default_namespace = default_namespace
+    self.default_stack_offset = default_stack_offset
+    self.default_clear_line = default_clear_line
+    self.root_dir = root_dir
+  
+  def _get_default_logger(self):
+    """Create a default logger.
+    The default logger prints INFO level messages to stdout.
+    """
+    logger = logging.getLogger('mllog')
+    logger.setLevel(logging.INFO)
+    _stream_handler = logging.StreamHandler(stream=sys.stdout)
+    _stream_handler.setLevel(logging.INFO)
+    logger.addHandler(_stream_handler)
+    return logger
+
+  def _do_log(self, message, clear_line=False):
+    if clear_line:
+      message = '\n' + message
+    self.logger.info(message)
+
+  def _log_helper(self, event_type, key, value, namespace=None, time_ms=None,
+                  stack_offset=None, clear_line=None):
     """Log an event."""
     if namespace is None:
       namespace = self.default_namespace
-    if time_ns is None:
-      time_ns = _current_time_ns()
+    if time_ms is None:
+      time_ms = _current_time_ms()
+    if stack_offset is None:
+      stack_offset = self.default_stack_offset
+    if clear_line is None:
+      clear_line = self.default_clear_line
+
+    call_site = get_caller(2 + stack_offset, root_dir=self.root_dir)
 
     log_line = _encode_log(
         namespace,
-        time_ns,
+        time_ms,
         event_type,
         key,
-        log_value)
+        value,
+        call_site)
+    
+    self._do_log(log_line, clear_line)
 
-    if self.log_info:
-      LOGGER.info(log_line)
-    if self.log_file:
-      self.log_file.write(log_line + '\n')
-
-  def start(self, key, log_value, namespace=None, time_ns=None):
+  def start(self, key, value, namespace=None, time_ms=None,
+            stack_offset=None, clear_line=None):
     """Start an time interval in the log.
     All intervals which are started must be ended. This interval must be
     ended before a new interval with the same key and namespace can be started.
     Args:
       key: the key for the event, e.g. "mlperf.training"
-      log_value: the json value to log.
+      value: the json value to log.
       namespace: override the default namespace.
-      time_ns: the time in nanoseconds, or None for current time.
+      time_ms: the time in milliseconds, or None for current time.
+      stack_offset: override the default stack offset, i.e. the depth to go
+        into the stack to find the call site.
+      clear_line: override the default line clearing behavior, i.e. whether to
+        print an extra new line to clear pre-existing text in the log line.
     """
-    self._log_helper(key, log_value, namespace, 'INTERVAL_START',
-                     time_ns=time_ns)
+    self._log_helper(constants.INTERVAL_START, key, value,
+                     namespace=namespace, time_ms=time_ms,
+                     stack_offset=stack_offset, clear_line=clear_line)
 
-  def end(self, key, log_value, namespace=None, time_ns=None):
+  def end(self, key, value, namespace=None, time_ms=None,
+          stack_offset=None, clear_line=None):
     """End a time interval in the log.
     Ends an interval which was already started with the same key and in the
     same namespace.
     Args:
       key: the same log key which was passed to start().
-      log_value: the value to log at the end of the interval.
+      value: the value to log at the end of the interval.
       namespace: optional override of the default namespace.
-      time_ns: the time in nanoseconds, or None for current time.
+      time_ms: the time in milliseconds, or None for current time.
+      stack_offset: override the default stack offset, i.e. the depth to go
+        into the stack to find the call site.
+      clear_line: override the default line clearing behavior, i.e. whether to
+        print an extra new line to clear pre-existing text in the log line.
     """
-    self._log_helper(key, log_value, namespace, 'INTERVAL_END',
-                     time_ns=time_ns)
+    self._log_helper(constants.INTERVAL_END, key, value,
+                     namespace=namespace, time_ms=time_ms,
+                     stack_offset=stack_offset, clear_line=clear_line)
 
-  def event(self, key, log_value, namespace=None, time_ns=None):
+  def event(self, key, value, namespace=None, time_ms=None,
+            stack_offset=None, clear_line=None):
     """Log a point in time event.
     The event does not have an associated duration like an interval has.
     Args:
       key: the "name" of the event.
-      log_value: the event data itself.
+      value: the event data itself.
       namespace: optional override of the default namespace.
-      time_ns: the time in nanoseconds, or None for current time.
+      time_ms: the time in milliseconds, or None for current time.
+      stack_offset: override the default stack offset, i.e. the depth to go
+        into the stack to find the call site.
+      clear_line: override the default line clearing behavior, i.e. whether to
+        print an extra new line to clear pre-existing text in the log line.
     """
-    self._log_helper(key, log_value, namespace, 'POINT_IN_TIME',
-                     time_ns=time_ns)
+    self._log_helper(constants.POINT_IN_TIME, key, value,
+                     namespace=namespace, time_ms=time_ms,
+                     stack_offset=stack_offset, clear_line=clear_line)

--- a/compliance/mllog/mllog.py
+++ b/compliance/mllog/mllog.py
@@ -184,8 +184,8 @@ class MLLogger(object):
       message = '\n' + message
     self.logger.log(level, message)
 
-  def _log_helper(self, event_type, key, value, metadata=None, namespace=None,
-                  time_ms=None, stack_offset=None, clear_line=None):
+  def _log_helper(self, event_type, key, value=None, metadata=None,
+        namespace=None, time_ms=None, stack_offset=None, clear_line=None):
     """Log an event."""
     if namespace is None:
       namespace = self.default_namespace
@@ -220,14 +220,14 @@ class MLLogger(object):
 
     self._do_log(logging.INFO, log_line, clear_line)
 
-  def start(self, key, value, metadata=None, namespace=None, time_ms=None,
+  def start(self, key, value=None, metadata=None, namespace=None, time_ms=None,
             stack_offset=None, clear_line=None):
     """Start an time interval in the log.
     All intervals which are started must be ended. This interval must be
     ended before a new interval with the same key and namespace can be started.
     Args:
       key: the key for the event, e.g. "mlperf.training"
-      value: the json value to log.
+      value: the value to log at the start of the interval.
       metadata: a dictionary containing metadata corresponding to the log event.
       namespace: override the default namespace.
       time_ms: the time in milliseconds, or None for current time.
@@ -240,7 +240,7 @@ class MLLogger(object):
                      metadata=metadata, namespace=namespace, time_ms=time_ms,
                      stack_offset=stack_offset, clear_line=clear_line)
 
-  def end(self, key, value, metadata=None, namespace=None, time_ms=None,
+  def end(self, key, value=None, metadata=None, namespace=None, time_ms=None,
           stack_offset=None, clear_line=None):
     """End a time interval in the log.
     Ends an interval which was already started with the same key and in the
@@ -260,7 +260,7 @@ class MLLogger(object):
                      metadata=metadata, namespace=namespace, time_ms=time_ms,
                      stack_offset=stack_offset, clear_line=clear_line)
 
-  def event(self, key, value, metadata=None, namespace=None, time_ms=None,
+  def event(self, key, value=None, metadata=None, namespace=None, time_ms=None,
             stack_offset=None, clear_line=None):
     """Log a point in time event.
     The event does not have an associated duration like an interval has.

--- a/compliance/mllog/test_mllog.py
+++ b/compliance/mllog/test_mllog.py
@@ -54,7 +54,7 @@ class TestMlperfLog(unittest.TestCase):
     mllog.mllog.get_caller = self.origin_get_caller
     time.time = self.origin_time
 
-  def _fake_do_log(self, message, clear_line=False):
+  def _fake_do_log(self, level, message, clear_line=False):
     if clear_line:
       print("\n" + message)
     else:
@@ -69,7 +69,7 @@ class TestMlperfLog(unittest.TestCase):
           "event_type": "INTERVAL_START",
           "key": "run_start",
           "value": null,
-          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+          "metadata": {"file": "mybenchmark/file.py", "lineno": 42}
         }''', object_pairs_hook=collections.OrderedDict))
     expected_output = " ".join([prefix, expected_log_json])
     with _captured_stdout() as out:
@@ -86,7 +86,7 @@ class TestMlperfLog(unittest.TestCase):
           "event_type": "INTERVAL_END",
           "key": "run_stop",
           "value": null,
-          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+          "metadata": {"file": "mybenchmark/file.py", "lineno": 42}
         }''', object_pairs_hook=collections.OrderedDict))
     expected_output = " ".join([prefix, expected_log_json])
     with _captured_stdout() as out:
@@ -103,7 +103,7 @@ class TestMlperfLog(unittest.TestCase):
           "event_type": "POINT_IN_TIME",
           "key": "eval_accuracy",
           "value": 0.99,
-          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+          "metadata": {"file": "mybenchmark/file.py", "lineno": 42}
         }''', object_pairs_hook=collections.OrderedDict))
     expected_output = " ".join([prefix, expected_log_json])
     with _captured_stdout() as out:
@@ -120,7 +120,7 @@ class TestMlperfLog(unittest.TestCase):
           "event_type": "POINT_IN_TIME",
           "key": "eval_accuracy",
           "value": 0.99,
-          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+          "metadata": {"file": "mybenchmark/file.py", "lineno": 42}
         }''', object_pairs_hook=collections.OrderedDict))
     expected_output = "\n" + " ".join([prefix, expected_log_json]) + "\n"
     with _captured_stdout() as out:

--- a/compliance/mllog/test_mllog.py
+++ b/compliance/mllog/test_mllog.py
@@ -1,0 +1,134 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import collections
+from contextlib import contextmanager
+import io
+import json
+import os
+import sys
+import time
+import unittest
+from unittest import mock
+
+import mllog
+from mllog import constants
+
+
+@contextmanager
+def _captured_stdout():
+  cap_out = io.StringIO()
+  old_out = sys.stdout
+  try:
+    sys.stdout = cap_out
+    yield sys.stdout
+  finally:
+    sys.stdout = old_out
+
+class TestMlperfLog(unittest.TestCase):
+
+  def setUp(self):
+    self.origin_get_caller = mllog.mllog.get_caller
+    mllog.mllog.get_caller = mock.MagicMock(
+        return_value={"file": "mybenchmark/file.py", "lineno": 42})
+
+    self.origin_do_log = mllog.mllog.MLLogger._do_log
+    mllog.mllog.MLLogger._do_log = mock.Mock(side_effect=self._fake_do_log)
+
+    self.origin_time = time.time
+    time.time = mock.MagicMock(return_value=1234567890.123)
+
+  def tearDown(self):
+    mllog.mllog.get_caller = self.origin_get_caller
+    time.time = self.origin_time
+
+  def _fake_do_log(self, message, clear_line=False):
+    if clear_line:
+      print("\n" + message)
+    else:
+      print(message)
+
+  def test_mllog_start_simple(self):
+    prefix = ":::MLLOG"
+    expected_log_json = json.dumps(json.loads(r'''
+        {
+          "namespace": "",
+          "time_ms": 1234567890123,
+          "event_type": "INTERVAL_START",
+          "key": "run_start",
+          "value": null,
+          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+        }''', object_pairs_hook=collections.OrderedDict))
+    expected_output = " ".join([prefix, expected_log_json])
+    with _captured_stdout() as out:
+      mllogger = mllog.get_mllogger()
+      mllogger.start(constants.RUN_START, None)
+      self.assertEqual(out.getvalue().splitlines()[0], expected_output)
+
+  def test_mllog_end_simple(self):
+    prefix = ":::MLLOG"
+    expected_log_json = json.dumps(json.loads(r'''
+        {
+          "namespace": "",
+          "time_ms": 1234567890123,
+          "event_type": "INTERVAL_END",
+          "key": "run_stop",
+          "value": null,
+          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+        }''', object_pairs_hook=collections.OrderedDict))
+    expected_output = " ".join([prefix, expected_log_json])
+    with _captured_stdout() as out:
+      mllogger = mllog.get_mllogger()
+      mllogger.end(constants.RUN_STOP, None)
+      self.assertEqual(out.getvalue().splitlines()[0], expected_output)
+
+  def test_mllog_event_simple(self):
+    prefix = ":::MLLOG"
+    expected_log_json = json.dumps(json.loads(r'''
+        {
+          "namespace": "",
+          "time_ms": 1234567890123,
+          "event_type": "POINT_IN_TIME",
+          "key": "eval_accuracy",
+          "value": 0.99,
+          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+        }''', object_pairs_hook=collections.OrderedDict))
+    expected_output = " ".join([prefix, expected_log_json])
+    with _captured_stdout() as out:
+      mllogger = mllog.get_mllogger()
+      mllogger.event(constants.EVAL_ACCURACY, 0.99)
+      self.assertEqual(out.getvalue().splitlines()[0], expected_output)
+
+  def test_mllog_event_override_param(self):
+    prefix = ":::MLLOG"
+    expected_log_json = json.dumps(json.loads(r'''
+        {
+          "namespace": "worker1",
+          "time_ms": 1231231230123,
+          "event_type": "POINT_IN_TIME",
+          "key": "eval_accuracy",
+          "value": 0.99,
+          "call_site": {"file": "mybenchmark/file.py", "lineno": 42}
+        }''', object_pairs_hook=collections.OrderedDict))
+    expected_output = "\n" + " ".join([prefix, expected_log_json]) + "\n"
+    with _captured_stdout() as out:
+      mllogger = mllog.get_mllogger()
+      mllogger.event(constants.EVAL_ACCURACY, 0.99, namespace="worker1",
+                     time_ms=1231231230123, clear_line=True)
+      self.assertEqual(out.getvalue(), expected_output)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/mlperf/training/tree/master/compliance",
-    packages=['mllog'],
+    packages=setuptools.find_namespace_packages(include=['mllog*']),
     classifiers=[
       "Programming Language :: Python :: 2",
       "Programming Language :: Python :: 3",

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018 MLBenchmark Group. All Rights Reserved.
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,14 +20,14 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.10",
-    author="Taylor Robie",
-    author_email="taylorrobie@google.com",
-    description="Tools for logging MLPerf compliance tags.",
+    version="0.1.0",
+    author="MLPerf.org",
+    author_email="mlperf@googlegroups.com",
+    description="MLPerf compliance tools.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/mlperf/training/tree/master/compliance",
-    packages=['mlperf_compliance'],
+    packages=['mllog'],
     classifiers=[
       "Programming Language :: Python :: 2",
       "Programming Language :: Python :: 3",


### PR DESCRIPTION
- Changes in log format
  - add call_site field to the log json to show the file and line no. info
  - change time_ns to time_ms since ms was previously agreed also time() doesn't have enough precision
- Changes in MLLogger
  - replace attributes log_info and log_file with a logging.Logger instance for full flexibility
  - add stack_offset attribute for adjusting stack depth in finding call sites
  - add clear_line attribute to allow clearing possible pre-existing texts in a log line
- Added a shared MLLogger instance at mllog package level
- Added readme
- Added a dummy example
- Added basic unit tests
- Updated setup.py