### PR TITLE
[single_stage_detector] evaluation, warmup and lr decay on epoch boundaries

### DIFF
--- a/single_stage_detector/Dockerfile
+++ b/single_stage_detector/Dockerfile
@@ -1,7 +1,7 @@
 FROM pytorch/pytorch:1.0.1-cuda10.0-cudnn7-runtime
 
 # Set working directory
-WORKDIR /mlperf
+WORKDIR /mlperf/ssd
 
 RUN apt-get update && \
     apt-get install -y python3-tk python-pip && \
@@ -9,11 +9,10 @@ RUN apt-get update && \
 
 RUN pip install --upgrade pip
 
-# Copy SSD code
-WORKDIR /mlperf
-COPY . .
 # Necessary pip packages
+COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 RUN python3 -m pip install pycocotools==2.0.0
 
-WORKDIR /mlperf/ssd
+# Copy SSD code
+COPY ssd .

--- a/single_stage_detector/ssd/config_DGX1_multinode.sh
+++ b/single_stage_detector/ssd/config_DGX1_multinode.sh
@@ -3,7 +3,7 @@
 ## DL params
 EXTRA_PARAMS=(
                --batch-size      "64"
-               --warmup          "300"
+               --warmup          "2.619685" # 300 iterations * 8 GPUs * 2 nodes * 64 batch size / 117266 non-empty images
              )
 
 ## System run parms

--- a/single_stage_detector/ssd/config_DGX1_singlenode.sh
+++ b/single_stage_detector/ssd/config_DGX1_singlenode.sh
@@ -3,7 +3,7 @@
 ## DL params
 EXTRA_PARAMS=(
                --batch-size      "128"
-               --warmup          "300"
+               --warmup          "2.619685" # 300 iterations * 8 GPUs * 1 nodes * 128 batch size / 117266 non-empty images
              )
 
 ## System run parms


### PR DESCRIPTION
Resolves issues #290 and https://github.com/mlperf/training_policies/issues/210
Included changes:
- evaluation and LR decay are moved out of the train loop and are executed on epoch boundaries
- warmup argument is provided per epochs as float
- quote from the #290:
> The factor wb discussed in rule 9.1 will be calculated as this parameter times the number of non-empty images in an epoch (117266) divided by N_gpu*batch_size, and rounded down to the nearest integer.
- aligning configs to the changes
- Dockerfile cleanup

The convergence rate was tested and is ok.