### PR TITLE
[SSD] Option to load pretrained weights from file

### DIFF
--- a/single_stage_detector/download_resnet34_backbone.sh
+++ b/single_stage_detector/download_resnet34_backbone.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd ssd/
+curl -O https://download.pytorch.org/models/resnet34-333f7ec4.pth
+

--- a/single_stage_detector/ssd/README.md
+++ b/single_stage_detector/ssd/README.md
@@ -30,6 +30,21 @@ cd reference/single_stage_detector/
 source download_dataset.sh
 ```
 
+### ResNet34 pretrained weights
+ResNet34 backbone is initialized with weights from PyTorch hub:
+https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
+
+By default, the code will automatically download the weights to
+`$TORCH_HOME/models` (default is `~/.torch/models/`) and save them for later use.
+
+Alternatively, you can manually download the weights with:
+```
+cd reference/single_stage_detector/
+./download_resnet34_backbone.sh
+```
+
+Then use the downloaded file with `--pretrained-backbone <PATH TO WEIGHTS>` .
+
 ### Steps to run benchmark.
 
 ## Steps to launch training

--- a/single_stage_detector/ssd/base_model.py
+++ b/single_stage_detector/ssd/base_model.py
@@ -54,9 +54,11 @@ class ResNet18(nn.Module):
         return [layer2_activation]
 
 class ResNet34(nn.Module):
-    def __init__(self):
+    def __init__(self, model_path=None):
         super().__init__()
-        rn34 = resnet34(pretrained=True)
+        rn34 = resnet34(pretrained=(model_path is None))
+        if model_path is not None:
+            rn34.load_state_dict(torch.load(model_path))
 
         # discard last Resnet block, avrpooling and classification FC
         self.layer1 = nn.Sequential(*list(rn34.children())[:6])

--- a/single_stage_detector/ssd/mlperf_logger.py
+++ b/single_stage_detector/ssd/mlperf_logger.py
@@ -48,7 +48,7 @@ def get_rank():
     if torch.distributed.is_initialized():
         rank = torch.distributed.get_rank()
     else:
-        rank = 0
+        rank = os.getenv('RANK', os.getenv('LOCAL_RANK', 0))
     return rank
 
 def broadcast_seeds(seed, device):

--- a/single_stage_detector/ssd/ssd300.py
+++ b/single_stage_detector/ssd/ssd300.py
@@ -10,14 +10,14 @@ class SSD300(nn.Module):
         vggt: pretrained vgg16 (partial) model
         label_num: number of classes (including background 0)
     """
-    def __init__(self, label_num, backbone='resnet34', model_path="./resnet34-333f7ec4.pth"):
+    def __init__(self, label_num, backbone='resnet34', model_path=None):
 
         super(SSD300, self).__init__()
 
         self.label_num = label_num
 
         if backbone == 'resnet34':
-            self.model = ResNet34()
+            self.model = ResNet34(model_path=model_path)
             out_channels = 256
             out_size = 38
             self.out_chan = [out_channels, 512, 512, 256, 256, 256]

--- a/single_stage_detector/ssd/train.py
+++ b/single_stage_detector/ssd/train.py
@@ -49,7 +49,7 @@ def parse_args():
     parser.add_argument('--lr', type=float, default=2.5e-3,
                         help='base learning rate')
     # Distributed stuff
-    parser.add_argument('--local_rank', default=0, type=int,
+    parser.add_argument('--local_rank', default=os.getenv('LOCAL_RANK', 0), type=int,
                         help='Used for multi-process training. Can either be manually set '
                              'or automatically set by using \'python -m multiproc\'.')
 
@@ -186,6 +186,10 @@ def train300_mlperf_coco(args):
     torch.manual_seed(local_seed)
     np.random.seed(seed=local_seed)
 
+    args.rank = dist.get_rank() if args.distributed else args.local_rank
+    print("args.rank = {}".format(args.rank))
+    print("local rank = {}".format(args.local_rank))
+    print("distributed={}".format(args.distributed))
 
     dboxes = dboxes300_coco()
     encoder = Encoder(dboxes)
@@ -214,7 +218,7 @@ def train300_mlperf_coco(args):
                                   shuffle=(train_sampler is None),
                                   sampler=train_sampler,
                                   num_workers=4)
-    # set shuffle=True in DataLoader    
+    # set shuffle=True in DataLoader
 
     ssd300 = SSD300(train_coco.labelnum)
     if args.checkpoint is not None:
@@ -312,7 +316,6 @@ def train300_mlperf_coco(args):
 
             iter_num += 1
         if epoch + 1 in eval_points:
-            rank = dist.get_rank() if args.distributed else args.local_rank
             if args.distributed:
                 world_size = float(dist.get_world_size())
                 for bn_name, bn_buf in ssd300.module.named_buffers(recurse=True):
@@ -321,7 +324,7 @@ def train300_mlperf_coco(args):
                         bn_buf /= world_size
                         ssd_print(key=mllog_const.MODEL_BN_SPAN,
                             value=bn_buf)
-            if rank == 0:
+            if args.rank == 0:
                 if not args.no_save:
                     print("")
                     print("saving model...")

--- a/single_stage_detector/ssd/train.py
+++ b/single_stage_detector/ssd/train.py
@@ -20,6 +20,9 @@ def parse_args():
                                         " on COCO")
     parser.add_argument('--data', '-d', type=str, default='/coco',
                         help='path to test and training data files')
+    parser.add_argument('--pretrained-backbone', type=str, default=None,
+                        help='path to pretrained backbone weights file, '
+                             'default is to get it from online torchvision repository')
     parser.add_argument('--epochs', '-e', type=int, default=800,
                         help='number of epochs for training')
     parser.add_argument('--batch-size', '-b', type=int, default=32,
@@ -220,7 +223,7 @@ def train300_mlperf_coco(args):
                                   num_workers=4)
     # set shuffle=True in DataLoader
 
-    ssd300 = SSD300(train_coco.labelnum)
+    ssd300 = SSD300(train_coco.labelnum, model_path=args.pretrained_backbone)
     if args.checkpoint is not None:
         print("loading model checkpoint", args.checkpoint)
         od = torch.load(args.checkpoint)


### PR DESCRIPTION
Add the option to load pretrained weights from a local file with `--pretrained-backbone <PATH>`.
Updated README with pretrained weights information and download scripts


depends on https://github.com/mlperf/training/pull/416